### PR TITLE
[RFR] Change login page styling

### DIFF
--- a/cas-server-webapp/src/main/webapp/WEB-INF/view/jsp/default/ui/includes/top.jsp
+++ b/cas-server-webapp/src/main/webapp/WEB-INF/view/jsp/default/ui/includes/top.jsp
@@ -32,6 +32,7 @@
   <meta charset="UTF-8" />
 
   <%-- <title>CAS &#8211; Central Authentication Service</title> --%>
+  <title>Open Science Framework | Sign In</title>
 
   <spring:theme code="standard.custom.css.file" var="customCssFile" />
   <link rel="stylesheet" href="<c:url value="${customCssFile}" />" />

--- a/cas-server-webapp/src/main/webapp/WEB-INF/view/jsp/default/ui/includes/top.jsp
+++ b/cas-server-webapp/src/main/webapp/WEB-INF/view/jsp/default/ui/includes/top.jsp
@@ -32,7 +32,6 @@
   <meta charset="UTF-8" />
 
   <%-- <title>CAS &#8211; Central Authentication Service</title> --%>
-  <title>Open Science Framework | Sign In</title>
 
   <spring:theme code="standard.custom.css.file" var="customCssFile" />
   <link rel="stylesheet" href="<c:url value="${customCssFile}" />" />
@@ -47,7 +46,10 @@
       <header>
         <%-- <a id="logo" href="http://www.apereo.org" title="<spring:message code="logo.title" />">Apereo</a>
         <h1>Central Authentication Service (CAS)</h1> --%>
-        <a id="logo" href="" title="<spring:message code="logo.title" />">Open Science Framework | Sign In</a>
+        <a id="logo" href="http://www.osf.io" title="<spring:message code="logo.title" />">Open Science Framework | Sign In</a>
+        <div align="center" class="center">
+        <span id="title">Open Science Framework</span>
+        </div>
         <%-- <h1>Central Authentication Service (CAS)</h1> --%>
       </header>
       <div id="content">

--- a/cas-server-webapp/src/main/webapp/css/cas.css
+++ b/cas-server-webapp/src/main/webapp/css/cas.css
@@ -36,6 +36,16 @@ h2 {
  padding-bottom: 10px;
 }
 
+#title {
+ font-size: 34px;
+ font-family: 'Open Sans';
+ font-weight: bold;
+
+}
+.center {
+ padding-top: 30px;
+}
+
 #container { width: 100%; }
 
 @media only screen and (max-width: 960px) { 
@@ -66,11 +76,11 @@ header {
 
 #logo {
   display: block;
-  width: 189px;
-  height: 75px;
+  width: 140px;
+  height:140px;
   margin: 0 auto;
-  background: url(../images/cos-logo.png) no-repeat;
-  background-size: 189px 75px;
+  background: url(../images/osf-logo.png) no-repeat;
+  background-size: 140px 140px;
   text-indent: -999em;
   border-right: 1px solid rgba(255,255,255,0.25);
 }


### PR DESCRIPTION
The login page does not display the osf logo.  This can be confusing to users who are expecting to be on the osf, and end up on a page that says COS.  Also, the logo will return you to the osf homepage.  
## Before

<img width="1440" alt="screen shot 2016-04-21 at 1 19 42 pm 2" src="https://cloud.githubusercontent.com/assets/6232068/14718288/d4b3ad62-07c3-11e6-88a0-4a52c0d98122.png">
## After

<img width="1440" alt="screen shot 2016-04-21 at 1 20 17 pm 2" src="https://cloud.githubusercontent.com/assets/6232068/14718297/dbd12386-07c3-11e6-90b0-948416810f91.png">
