### PR TITLE
Add HttpOnly support for CAS TGC [DEV-93]

### DIFF
--- a/cas-server-support-osf/src/main/java/io/cos/cas/web/support/OpenScienceFrameworkCookieRetrievingCookieGenerator.java
+++ b/cas-server-support-osf/src/main/java/io/cos/cas/web/support/OpenScienceFrameworkCookieRetrievingCookieGenerator.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to Apereo under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work
+ * for additional information regarding copyright ownership.
+ * Apereo licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License.  You may obtain a
+ * copy of the License at the following location:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package io.cos.cas.web.support;
 
 import org.jasig.cas.web.support.CookieValueManager;
@@ -5,16 +23,32 @@ import org.jasig.cas.web.support.CookieRetrievingCookieGenerator;
 
 import javax.servlet.http.Cookie;
 
-
+/**
+ * Add HttpOnly Support for CookieRetrievingCookieGenerator. This is a temporary fix.
+ *
+ * @author Longze Chen
+ * @since 4.1.0
+ */
 public class OpenScienceFrameworkCookieRetrievingCookieGenerator extends CookieRetrievingCookieGenerator {
 
-    public OpenScienceFrameworkCookieRetrievingCookieGenerator(CookieValueManager casCookieValueManager) {
+    /**
+     * Constructor with CookieValueManager.
+     *
+     * @param casCookieValueManager CAS Cookie Value Manager
+     */
+    public OpenScienceFrameworkCookieRetrievingCookieGenerator(final CookieValueManager casCookieValueManager) {
         super(casCookieValueManager);
     }
 
+    /**
+     * Override CookieGenerator.createCookie(String cookieValue) to add HttpOnly.
+     *
+     * @param cookieValue Cookie Value
+     * @return return the cookie
+     */
     @Override
-    protected Cookie createCookie(String cookieValue) {
-        Cookie cookie = super.createCookie(cookieValue);
+    protected Cookie createCookie(final String cookieValue) {
+        final Cookie cookie = super.createCookie(cookieValue);
         cookie.setHttpOnly(super.isCookieHttpOnly());
         return cookie;
     }

--- a/cas-server-support-osf/src/main/java/io/cos/cas/web/support/OpenScienceFrameworkCookieRetrievingCookieGenerator.java
+++ b/cas-server-support-osf/src/main/java/io/cos/cas/web/support/OpenScienceFrameworkCookieRetrievingCookieGenerator.java
@@ -1,0 +1,21 @@
+package io.cos.cas.web.support;
+
+import org.jasig.cas.web.support.CookieValueManager;
+import org.jasig.cas.web.support.CookieRetrievingCookieGenerator;
+
+import javax.servlet.http.Cookie;
+
+
+public class OpenScienceFrameworkCookieRetrievingCookieGenerator extends CookieRetrievingCookieGenerator {
+
+    public OpenScienceFrameworkCookieRetrievingCookieGenerator(CookieValueManager casCookieValueManager) {
+        super(casCookieValueManager);
+    }
+
+    @Override
+    protected Cookie createCookie(String cookieValue) {
+        Cookie cookie = super.createCookie(cookieValue);
+        cookie.setHttpOnly(super.isCookieHttpOnly());
+        return cookie;
+    }
+}

--- a/cas-server-webapp/src/main/webapp/WEB-INF/spring-configuration/ticketGrantingTicketCookieGenerator.xml
+++ b/cas-server-webapp/src/main/webapp/WEB-INF/spring-configuration/ticketGrantingTicketCookieGenerator.xml
@@ -31,9 +31,11 @@
         You can change the name if you want to make it harder for people to guess.
     </description>
 
-    <bean id="ticketGrantingTicketCookieGenerator" class="org.jasig.cas.web.support.CookieRetrievingCookieGenerator"
+    <bean id="ticketGrantingTicketCookieGenerator"
+          class="io.cos.cas.web.support.OpenScienceFrameworkCookieRetrievingCookieGenerator"
           c:casCookieValueManager-ref="cookieValueManager"
           p:cookieSecure="${tgc.cookie.secure:true}"
+          p:cookieHttpOnly="${tgc.cookie.httponly:true}"
           p:cookieMaxAge="-1"
           p:rememberMeMaxAge="${tgt.rememberMeDuration:1209600}"
           p:cookieName="TGC"

--- a/cas-server-webapp/src/main/webapp/WEB-INF/spring-configuration/ticketGrantingTicketCookieGenerator.xml
+++ b/cas-server-webapp/src/main/webapp/WEB-INF/spring-configuration/ticketGrantingTicketCookieGenerator.xml
@@ -37,7 +37,7 @@
           p:cookieMaxAge="-1"
           p:rememberMeMaxAge="${tgt.rememberMeDuration:1209600}"
           p:cookieName="TGC"
-          p:cookiePath="/cas"/>
+          p:cookiePath="/"/>
 
     <bean id="cookieCipherExecutor" class="org.jasig.cas.util.DefaultCipherExecutor"
           c:secretKeyEncryption="${tgc.encryption.key}"

--- a/etc/cas.properties
+++ b/etc/cas.properties
@@ -116,8 +116,11 @@ tgc.encryption.key=1PbwSbnHeinpkZOSZjuSJ8yYpUrInm5aaV18J2Ar4rM
 # The signing secret key. By default, must be a octet string of size 512.
 tgc.signing.key=szxK-5_eJjs-aUj-64MpUZ-GPPzGLhYPLGl0wrYjYNVAGva2P0lLe6UGKGM7k8dWxsOVGutZWgvmY3l5oVPO3w
 
-# Allow non-secure cookie generation, ONLY set this `false` for development.
+# Allow non-secure cookie generation, Must set this `true` for production.
 tgc.cookie.secure=false
+
+# Do not allow client side script to access the cookie, MUST set this `true` for production.
+tgc.cookie.httponly=true
 
 ##
 # CAS Logout Behavior


### PR DESCRIPTION
Jira Ticket: [DEV-93](https://openscience.atlassian.net/browse/DEV-93)

TGC missing `HttpOnly` flag is due to a bug in Apereo CAS: class `CookieRetrievingCookieGenerator` is not fully implemented to support `HttpOnly` when `RememberMe` is set.

The temporary fix is to create a class that extends `CookieRetrievingCookieGenerator`. The new one overrides method `createCookie()` from class `CookieGenerator` and set `HttpOnly` flag.

The long term fix is to submit a PR to fix `addCookie()` in `CookieRetrievingCookieGenerator` for Apereo. [Apereo-CAS-#1769](https://github.com/apereo/cas/pull/1769)
