### PR TITLE
[Fix] Fix and improve OAuth authorization pages [CAS-14]

### DIFF
--- a/cas-server-webapp/src/main/resources/messages.properties
+++ b/cas-server-webapp/src/main/resources/messages.properties
@@ -151,4 +151,4 @@ screen.institution.login.message=If your institution has partnered with the Open
 
 # Sign in through OSF
 screen.osf.login.message=Sign in with your OSF Account to continue
-screen.cas.login.message=OSF central authentication and authorization system. No service is detected.
+screen.cas.login.message=OSF Central Authentication and Authorization System.

--- a/cas-server-webapp/src/main/resources/messages.properties
+++ b/cas-server-webapp/src/main/resources/messages.properties
@@ -131,7 +131,7 @@ screen.remoteuserfailedlogin.message=Please check with your Institution to verif
 
 # OAuth
 screen.oauth.confirm.header=Authorize Application
-screen.oauth.confirm.message=<h2>{0}</h2> would like permission to access your account.
+screen.oauth.confirm.message=<h2>{0}</h2> has asked for the following permission(s) to access your OSF account.
 screen.oauth.confirm.allow=ALLOW
 screen.oauth.confirm.deny=DENY
 screen.oauth.error.header=Authorization Error

--- a/cas-server-webapp/src/main/webapp/WEB-INF/view/jsp/default/ui/includes/bottom.jsp
+++ b/cas-server-webapp/src/main/webapp/WEB-INF/view/jsp/default/ui/includes/bottom.jsp
@@ -21,43 +21,47 @@
 
 <%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
 
-    <div class="row" style="text-align: center;">
-        <hr>
-        <br>
-        <c:choose>
-            <c:when test="${osfLoginContext.isInstitutionLogin()}">
-                <spring:eval var="osfLoginUrl" expression="@casProperties.getProperty('cas.osf.login.url')" />
-                <c:choose>
-                    <c:when test="${osfLoginContext.isServiceUrl()}">
-                        <a id="alternative-osf" href="${osfLoginUrl}service=${osfLoginContext.getServiceUrl()}">Non-institution Login</a>&nbsp;&nbsp;&nbsp;&nbsp;
-                    </c:when>
-                    <c:otherwise>
-                        <a id="alternative-osf" href="${osfLoginUrl}">Non-institution Login</a>&nbsp;&nbsp;&nbsp;&nbsp;
-                    </c:otherwise>
-                </c:choose>
-            </c:when>
-            <c:otherwise>
-                <spring:eval var="institutionLoginUrl" expression="@casProperties.getProperty('cas.institution.login.url')" />
-                <c:choose>
-                    <c:when test="${osfLoginContext.isServiceUrl()}">
-                        <a id="alternative-institution" href="${institutionLoginUrl}&service=${osfLoginContext.getServiceUrl()}">Login through Your Institution</a>&nbsp;&nbsp;&nbsp;&nbsp;
-                    </c:when>
-                    <c:otherwise>
-                        <a id="alternative-institution" href="${institutionLoginUrl}">Login through Your Institution</a>&nbsp;&nbsp;&nbsp;&nbsp;
-                    </c:otherwise>
-                </c:choose>
-            </c:otherwise>
-        </c:choose>
-        <spring:eval var="osfUrl" expression="@casProperties.getProperty('osf.url')" />
-        <a id="back-to-osf" href="${osfUrl}">Back&nbsp;to&nbsp;OSF</a><br>
-    </div>
+    <c:if test="${empty confirmAuthorization}">
+        <div class="row" style="text-align: center;">
+            <hr>
+            <br>
+            <c:choose>
+                <c:when test="${osfLoginContext.isInstitutionLogin()}">
+                    <spring:eval var="osfLoginUrl" expression="@casProperties.getProperty('cas.osf.login.url')" />
+                    <c:choose>
+                        <c:when test="${osfLoginContext.isServiceUrl()}">
+                            <a id="alternative-osf" href="${osfLoginUrl}service=${osfLoginContext.getServiceUrl()}">Non-institution Login</a>&nbsp;&nbsp;&nbsp;&nbsp;
+                        </c:when>
+                        <c:otherwise>
+                            <a id="alternative-osf" href="${osfLoginUrl}">Non-institution Login</a>&nbsp;&nbsp;&nbsp;&nbsp;
+                        </c:otherwise>
+                    </c:choose>
+                </c:when>
+                <c:otherwise>
+                    <spring:eval var="institutionLoginUrl" expression="@casProperties.getProperty('cas.institution.login.url')" />
+                    <c:choose>
+                        <c:when test="${osfLoginContext.isServiceUrl()}">
+                            <a id="alternative-institution" href="${institutionLoginUrl}&service=${osfLoginContext.getServiceUrl()}">Login through Your Institution</a>&nbsp;&nbsp;&nbsp;&nbsp;
+                        </c:when>
+                        <c:otherwise>
+                            <a id="alternative-institution" href="${institutionLoginUrl}">Login through Your Institution</a>&nbsp;&nbsp;&nbsp;&nbsp;
+                        </c:otherwise>
+                    </c:choose>
+                </c:otherwise>
+            </c:choose>
+            <spring:eval var="osfUrl" expression="@casProperties.getProperty('osf.url')" />
+            <a id="back-to-osf" href="${osfUrl}">Back&nbsp;to&nbsp;OSF</a><br>
+        </div>
+    </c:if>
 </div> <!-- END #content -->
 
-<div class="row" style="text-align: center;">
-    <br>
-    <spring:eval var="createAccountUrl" expression="@casProperties.getProperty('osf.createAccount.url')" />
-    <a id="create-account" href="${createAccountUrl}${registeredService.properties.registerUrl.getValue()}">Create Account</a>
-</div>
+<c:if test="${empty confirmAuthorization}">
+    <div class="row" style="text-align: center;">
+        <br>
+        <spring:eval var="createAccountUrl" expression="@casProperties.getProperty('osf.createAccount.url')" />
+        <a id="create-account" href="${createAccountUrl}${registeredService.properties.registerUrl.getValue()}">Create Account</a>
+    </div>
+</c:if>
 
 <footer>
     <%-- <div id="copyright">

--- a/cas-server-webapp/src/main/webapp/WEB-INF/view/jsp/default/ui/includes/bottom.jsp
+++ b/cas-server-webapp/src/main/webapp/WEB-INF/view/jsp/default/ui/includes/bottom.jsp
@@ -21,7 +21,7 @@
 
 <%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
 
-    <c:if test="${empty confirmAuthorization}">
+    <c:if test="${empty oauthAuthorization}">
         <div class="row" style="text-align: center;">
             <hr>
             <br>
@@ -53,9 +53,10 @@
             <a id="back-to-osf" href="${osfUrl}">Back&nbsp;to&nbsp;OSF</a><br>
         </div>
     </c:if>
+
 </div> <!-- END #content -->
 
-<c:if test="${empty confirmAuthorization}">
+<c:if test="${empty oauthAuthorization}">
     <div class="row" style="text-align: center;">
         <br>
         <spring:eval var="createAccountUrl" expression="@casProperties.getProperty('osf.createAccount.url')" />

--- a/cas-server-webapp/src/main/webapp/WEB-INF/view/jsp/protocol/oauth/confirm.jsp
+++ b/cas-server-webapp/src/main/webapp/WEB-INF/view/jsp/protocol/oauth/confirm.jsp
@@ -19,12 +19,7 @@
 
 --%>
 <jsp:directive.include file="../../default/ui/includes/top.jsp" />
-<style>
-    #login .btn-reset {
-        background: #ddd;
-        font-weight: bold;
-    }
-</style>
+
 <div class="question" id="login">
     <form id="fm1" method="GET" action="<c:url value="${callbackUrl}" />">
         <h2><spring:message code="screen.oauth.confirm.header" /></h2>
@@ -41,9 +36,11 @@
             </ul>
         </p>
         <section class="row btn-row">
-            <input class="btn-submit" style="width: inherit;" name="action" accesskey="a" value="<spring:message code="screen.oauth.confirm.allow" />" type="submit" />
-            <input class="btn-reset" style="display: inline-block;" name="action" accesskey="d" value="<spring:message code="screen.oauth.confirm.deny" />" type="submit" />
+            <input class="btn-oauth-submit" name="action" accesskey="a" value="<spring:message code="screen.oauth.confirm.allow" />" type="submit" />
+            &nbsp;
+            <input class="btn-oauth-reset" style="display: inline-block;" name="action" accesskey="d" value="<spring:message code="screen.oauth.confirm.deny" />" type="submit" />
         </section>
     </form>
 </div>
+
 <jsp:directive.include file="../../default/ui/includes/bottom.jsp" />

--- a/cas-server-webapp/src/main/webapp/WEB-INF/view/jsp/protocol/oauth/confirm.jsp
+++ b/cas-server-webapp/src/main/webapp/WEB-INF/view/jsp/protocol/oauth/confirm.jsp
@@ -22,10 +22,10 @@
 
 <div class="question" id="login">
     <form id="fm1" method="GET" action="<c:url value="${callbackUrl}" />">
-        <h2><spring:message code="screen.oauth.confirm.header" /></h2>
-        <p>
+        <div class="oauth-confirm-header"><spring:message code="screen.oauth.confirm.header" /></div><br><br>
+        <div>
            <spring:message code="screen.oauth.confirm.message" arguments="${fn:escapeXml(serviceName)}" />
-        </p>
+        </div>
         <p>
             <ul style="padding-left: 15px;">
                 <c:forEach items="${scopeMap}" var="scope">
@@ -42,5 +42,7 @@
         </section>
     </form>
 </div>
+
+<c:set var="confirmAuthorization" value="true"/>
 
 <jsp:directive.include file="../../default/ui/includes/bottom.jsp" />

--- a/cas-server-webapp/src/main/webapp/WEB-INF/view/jsp/protocol/oauth/confirm.jsp
+++ b/cas-server-webapp/src/main/webapp/WEB-INF/view/jsp/protocol/oauth/confirm.jsp
@@ -43,6 +43,6 @@
     </form>
 </div>
 
-<c:set var="confirmAuthorization" value="true"/>
+<c:set var="oauthAuthorization" value="true"/>
 
 <jsp:directive.include file="../../default/ui/includes/bottom.jsp" />

--- a/cas-server-webapp/src/main/webapp/WEB-INF/view/jsp/protocol/oauth/oAuthFailureView.jsp
+++ b/cas-server-webapp/src/main/webapp/WEB-INF/view/jsp/protocol/oauth/oAuthFailureView.jsp
@@ -19,9 +19,13 @@
 
 --%>
 <jsp:directive.include file="../../default/ui/includes/top.jsp" />
+
 <div id="msg" class="errors">
     <h2><spring:message code="screen.oauth.error.header" /></h2>
-    <p><spring:message code="${rootCauseException.message}" /></p>
     <p><spring:message code="${rootCauseException.code}" /></p>
+    <p><spring:message code="${rootCauseException.message}" /></p>
 </div>
+
+<c:set var="oauthAuthorization" value="true"/>
+
 <jsp:directive.include file="../../default/ui/includes/bottom.jsp" />

--- a/cas-server-webapp/src/main/webapp/css/cas.css
+++ b/cas-server-webapp/src/main/webapp/css/cas.css
@@ -434,3 +434,9 @@ footer a:link, footer a:visited {
   vertical-align: middle;
   white-space: nowrap;
 }
+
+#fm1 .oauth-confirm-header {
+  font-size: 24px;
+  font-weight: lighter;
+  white-space: nowrap;
+}

--- a/cas-server-webapp/src/main/webapp/css/cas.css
+++ b/cas-server-webapp/src/main/webapp/css/cas.css
@@ -200,9 +200,8 @@ header h1 {
   padding: 5px;
 }
 
-#login .btn-submit {
-  /*background: #2aa4a5;*/
-  background: #5cb85c;
+#login .btn-oauth-submit {
+  background-image: linear-gradient(to bottom, #5cb85c 0, #419641 100%);
   border: 0;
   padding: 10px 20px;
   font-weight: bold;
@@ -212,26 +211,31 @@ header h1 {
   border-radius: 4px;
 }
 
-#login .btn-reset {
-  background: #eee;
-  padding: 10px 20px;
+#login .btn-oauth-reset {
+  background-image: linear-gradient(to bottom, #d4d4d4 0, #c4c4c4 100%);
   border: 0;
+  padding: 10px 20px;
+  font-weight: bold;
+  color: black;
   -webkit-border-radius: 4px;
   -moz-border-radius: 4px;
   border-radius: 4px;
 }
 
-#login .btn-submit:hover, #login .btn-reset:hover {
+#login .btn-oauth-submit:hover {
   cursor: pointer;
 }
 
-#login .btn-submit:hover {
-  /*background: #30bfbf;*/
-  background: #419641;
+#login .btn-oauth-submit:active {
+  background-image: linear-gradient(to top, #5cb85c 0, #419641 100%);
 }
 
-#login .btn-reset:hover {
-  background: #d4d4d4;
+#login .btn-oauth-reset:hover {
+   cursor: pointer;
+ }
+
+#login .btn-oauth-reset:active {
+  background-image: linear-gradient(to top, #d4d4d4 0, #c4c4c4 100%);
 }
 
 #sidebar {

--- a/etc/services/cas.json
+++ b/etc/services/cas.json
@@ -4,10 +4,31 @@
   "name" : "",
   "description" : "",
   "serviceId" : "^https?://(localhost|127.0.0.1|accounts.dev.osf.io)(|:8080|:8443)/.*",
-  "evaluationOrder": "100",
+  "evaluationOrder": "2000",
   "logo": "",
   "attributeReleasePolicy" : {
     "@class" : "org.jasig.cas.services.ReturnAllowedAttributeReleasePolicy",
     "allowedAttributes" : [ "java.util.ArrayList", [ "givenName", "familyName" ] ]
+  },
+  "properties" : {
+    "@class": "java.util.HashMap",
+    "title": {
+      "@class": "org.jasig.cas.services.DefaultRegisteredServiceProperty",
+      "values": [
+        "java.util.HashSet",
+        [
+          "Open Science Framework"
+        ]
+      ]
+    },
+    "titleAbbr": {
+      "@class": "org.jasig.cas.services.DefaultRegisteredServiceProperty",
+      "values": [
+        "java.util.HashSet",
+        [
+          "OSF"
+        ]
+      ]
+    }
   }
 }

--- a/etc/services/oauth2.json
+++ b/etc/services/oauth2.json
@@ -1,8 +1,29 @@
 {
   "@class" : "org.jasig.cas.support.oauth.services.OAuthCallbackAuthorizeService",
   "id" : 983450982340993434,
-  "name" : "Open Science Framework",
-  "description" : "The Open Science Framework (OSF) supports the entire research lifecycle: planning, execution, reporting, archiving, and discovery.",
-  "serviceId" : "^https?://(localhost|127.0.0.1|accounts.dev.osf.io)(:8443)?/oauth2/callbackAuthorize",
-  "evaluationOrder": "100"
+  "name" : "",
+  "description" : "",
+  "serviceId" : "^https?://(localhost|127.0.0.1|accounts.dev.osf.io):(8443|8080)?/oauth2/callbackAuthorize",
+  "evaluationOrder": "1000",
+  "properties" : {
+    "@class": "java.util.HashMap",
+    "title": {
+      "@class": "org.jasig.cas.services.DefaultRegisteredServiceProperty",
+      "values": [
+        "java.util.HashSet",
+        [
+          "Open Science Framework"
+        ]
+      ]
+    },
+    "titleAbbr": {
+      "@class": "org.jasig.cas.services.DefaultRegisteredServiceProperty",
+      "values": [
+        "java.util.HashSet",
+        [
+          "OSF"
+        ]
+      ]
+    }
+  }
 }


### PR DESCRIPTION
### Purpose

- Remove "No Service is Detected" from generic header.
- Remove unrelated links for institution login, back to OSF and create account. The user must be logged in and registered for this page.
- Fix submit and reset buttons.
- Add title properties for oauth services, requires deployment update Michael Haselton.

Here is an example of the authorization page before and after:
- On Prod:
![cas-oauth-confirm-prod](https://cloud.githubusercontent.com/assets/3750414/20844751/55198464-b88f-11e6-9726-360553fa61fb.png)
- On Staging 1:
![cas-oauth-confirm-staging](https://cloud.githubusercontent.com/assets/3750414/20844764/65c2afca-b88f-11e6-86d2-9a4b1ea73f8a.png)
- In this PR:
![cas-oauth-confirm](https://cloud.githubusercontent.com/assets/3750414/20844829/c302cfda-b88f-11e6-81d4-580c44c9b0e7.png)

### Deployment Notes

@icereval 
Update services configuration:`cas.json` and `oauth2.json` for each environment.

### QA Notes

Try to login through OSF from Share or Experimenter which will request authorization. Verify that the content and layout of the page is good and that `ALLOW` and `DENY` are working as before.

### Ticket
https://openscience.atlassian.net/browse/CAS-14