### PR TITLE
[Fix] [Django-OSF] Fix Wrong Query for Two-Factor Authentication [No Ticket]

### DIFF
--- a/cas-server-support-osf/src/main/java/io/cos/cas/adaptors/postgres/daos/OpenScienceFrameworkDaoImpl.java
+++ b/cas-server-support-osf/src/main/java/io/cos/cas/adaptors/postgres/daos/OpenScienceFrameworkDaoImpl.java
@@ -104,7 +104,7 @@ public class OpenScienceFrameworkDaoImpl implements OpenScienceFrameworkDao {
     public OpenScienceFrameworkTimeBasedOneTimePassword findOneTimeBasedOneTimePasswordByOwnerId(final Integer ownerId) {
         try {
             final TypedQuery<OpenScienceFrameworkTimeBasedOneTimePassword> query = entityManager.createQuery(
-                    "select p from OpenScienceFrameworkTimeBasedOneTimePassword p where p.id = :ownerId",
+                    "select p from OpenScienceFrameworkTimeBasedOneTimePassword p where p.owner.id = :ownerId",
                     OpenScienceFrameworkTimeBasedOneTimePassword.class
             );
             query.setParameter("ownerId", ownerId);

--- a/etc/cas.properties
+++ b/etc/cas.properties
@@ -38,19 +38,34 @@ cas.osf.login.url=/login?
 cas.logout.url=/logout
 cas.institution.login.url=/login?campaign=institution
 
+##
+# Authentication Delegation: General
+#
+#delegation.redirect.uri=${DELEGATION_REDIRECT_URI:http://localhost:8080/login}
+delegation.redirect.uri=${DELEGATION_REDIRECT_URI:https://test-accounts.osf.io/login}
+oauth.redirect.uri=${delegation.redirect.uri}
+
+##
+# Authentication Delegation: Clients
+#
+# CAS: Oklahoma State University
+cas.okstate.login.url=${CAS_OKSTATE_LOGIN_URL:https://stwcas.okstate.edu/cas/login}
+cas.okstate.client.name=${CAS_OKSTATE_CLIENT_NAME:CasClientOkState}
+#
+# CAS: fakeCAS local
+cas.fakecas.login.url=http://localhost:8081/login
+cas.fakecas.client.name=CasClientFakeCas
+#
 # OAuth: ORCID
 #
 oauth.orcid.authorize.url=${OAUTH_ORCID_AUTHORIZATION_URL:https://orcid.org/oauth/authorize}
 oauth.orcid.token.url=${OAUTH_ORCID_TOKEN_URL:https://pub.orcid.org/oauth/token}
-oauth.orcid.client.id=${OAUTH_ORCID_CLIENT_ID:}
+#oauth.orcid.client.id=${OAUTH_ORCID_CLIENT_ID:APP-DBIDMSAU5FVV3IE5}
+oauth.orcid.client.id=${OAUTH_ORCID_CLIENT_ID:APP-EJ9IUZJ1VOG5S240}
 oauth.orcid.member=${OAUTH_ORCID_MEMBER:false}
-oauth.orcid.client.secret=${OAUTH_ORCID_CLIENT_SECRET:}
+#oauth.orcid.client.secret=${OAUTH_ORCID_CLIENT_SECRET:4df5e9e3-ed36-4bee-96c4-3ca3431d448b}
+oauth.orcid.client.secret=${OAUTH_ORCID_CLIENT_SECRET:b68f729b-7e58-4619-b98c-a54d45a42dc6}
 oauth.orcid.scope=${OAUTH_ORCID_SCOPE:/authenticate}
-
-##
-# OAuth: General
-#
-oauth.redirect.uri=http://localhost:8080/login
 
 ##
 # Open Science Framework URLs
@@ -70,8 +85,8 @@ osf.api.institutions.auth.xslLocation=file:institutions-auth.xsl
 #
 osf.database.driverClass=org.postgresql.Driver
 osf.database.url=jdbc:postgresql://${OSF_DB_PORT_5432_TCP_ADDR:127.0.0.1}:${OSF_DB_PORT_5432_TCP_PORT:5432}/osf?targetServerType=master
-osf.database.user=${CAS_DB_USERNAME:postgres}
-osf.database.password=${CAS_DB_PASSWORD:}
+osf.database.user=${CAS_DB_USERNAME:longzechen}
+osf.database.password=${CAS_DB_PASSWORD:abCD12#$}
 osf.database.hibernate.dialect=org.hibernate.dialect.PostgreSQL82Dialect
 
 ##
@@ -79,12 +94,14 @@ osf.database.hibernate.dialect=org.hibernate.dialect.PostgreSQL82Dialect
 #
 # OAuth Access Token session length in seconds
 oauth.accessTokenDuration=3600
-oauth.loginUrl=http://localhost:8080/login
+#oauth.loginUrl=http://localhost:8080/login
+oauth.loginUrl=https://test-accounts.osf.io/login
 
 
 #### Central Authentication Service ####
 
-server.name=http://localhost:8080
+#server.name=http://localhost:8080
+server.name=https://test-accounts.osf.io
 server.prefix=${server.name}
 
 # Spring Security's EL-based access rules for the /status URI of CAS that exposes health check information
@@ -121,8 +138,8 @@ database.hibernate.batchSize=1
 database.hibernate.showSql=true
 database.driverClass=org.postgresql.Driver
 database.url=jdbc:postgresql://${CAS_DB_PORT_5432_TCP_ADDR:127.0.0.1}:${CAS_DB_PORT_5432_TCP_PORT:5432}/cas?targetServerType=master
-database.user=${CAS_DB_USERNAME:postgres}
-database.password=${CAS_DB_PASSWORD:}
+database.user=${CAS_DB_USERNAME:longzechen}
+database.password=${CAS_DB_PASSWORD:abCD12#$}
 
 ##
 # CAS SSO Cookie Generation & Security

--- a/etc/institutions-auth.xsl
+++ b/etc/institutions-auth.xsl
@@ -10,11 +10,11 @@
         <xsl:variable name="idp" select="//attribute[@name='Shib-Identity-Provider']/@value" />
         <idp><xsl:value-of select="$idp"/></idp>
         <xsl:choose>
-            <xsl:when test="$idp='https://login.circle.edu/idp/shibboleth'">
-                <id>cir</id>
+            <!-- New York University (NYU) -->
+            <xsl:when test="$idp='https://shibbolethqa.es.its.nyu.edu/idp/shibboleth'">
+                <id>nyu</id>
                 <user>
                     <username><xsl:value-of select="//attribute[@name='eppn']/@value"/></username>
-                    <!--<email><xsl:value-of select="//attribute[@name='mail']/@value"/></email>-->
                     <fullname><xsl:value-of select="//attribute[@name='displayName']/@value"/></fullname>
                     <familyName/>
                     <givenName/>
@@ -22,6 +22,67 @@
                     <suffix/>
                 </user>
             </xsl:when>
+            <!-- University of Notre Dame (ND) -->
+            <xsl:when test="$idp='https://login-test.cc.nd.edu/idp/shibboleth'">
+                <id>nd</id>
+                <user>
+                    <username><xsl:value-of select="//attribute[@name='eppn']/@value"/></username>
+                    <fullname><xsl:value-of select="//attribute[@name='displayName']/@value"/></fullname>
+                    <familyName/>
+                    <givenName/>
+                    <middleNames/>
+                    <suffix/>
+                </user>
+            </xsl:when>
+            <!-- University of California Riverside (UCR) -->
+            <xsl:when test="$idp='urn:mace:incommon:ucr.edu'">
+                <id>ucr</id>
+                <user>
+                    <username><xsl:value-of select="//attribute[@name='eppn']/@value"/></username>
+                    <fullname><xsl:value-of select="//attribute[@name='displayName']/@value"/></fullname>
+                    <familyName><xsl:value-of select="//attribute[@name='sn']/@value"/></familyName>
+                    <givenName><xsl:value-of select="//attribute[@name='givenName']/@value"/></givenName>
+                    <middleNames/>
+                    <suffix/>
+                </user>
+            </xsl:when>
+            <!-- University of Southern California (USC) -->
+            <xsl:when test="$idp='https://shibboleth.usc.edu/shibboleth-idp'">
+                <id>usc</id>
+                <user>
+                    <username><xsl:value-of select="//attribute[@name='wuscEmailPrimaryAddress']/@value"/></username>
+                    <fullname><xsl:value-of select="//attribute[@name='uscDisplayGivenName']/@value"/><xsl:text> </xsl:text><xsl:value-of select="//attribute[@name='uscDisplaySn']/@value"/></fullname>
+                    <familyName><xsl:value-of select="//attribute[@name='uscDisplaySn']/@value"/></familyName>
+                    <givenName><xsl:value-of select="//attribute[@name='uscDisplayGivenName']/@value"/></givenName>
+                    <middleNames><xsl:value-of select="//attribute[@name='uscDisplayMiddleName']/@value"/></middleNames>
+                    <suffix/>
+                </user>
+            </xsl:when>
+            <!-- Universiteit Gent (UGENT) -->
+            <xsl:when test="$idp='https://identity.ugent.be/simplesaml/saml2/idp/metadata.php'">
+                <id>ugent</id>
+                <user>
+                    <username><xsl:value-of select="//attribute[@name='eppn']/@value"/></username>
+                    <fullname><xsl:value-of select="//attribute[@name='displayName']/@value"/></fullname>
+                    <familyName/>
+                    <givenName/>
+                    <middleNames/>
+                    <suffix/>
+                </user>
+            </xsl:when>
+            <!-- University of Virginia (UVA) -->
+            <xsl:when test="$idp='https://shibidp-test.its.virginia.edu/idp/shibboleth'">
+                <id>uva</id>
+                <user>
+                    <username><xsl:value-of select="//attribute[@name='eppn']/@value"/></username>
+                    <fullname><xsl:value-of select="//attribute[@name='displayName']/@value"/></fullname>
+                    <familyName/>
+                    <givenName/>
+                    <middleNames/>
+                    <suffix/>
+                </user>
+            </xsl:when>
+            <!-- Unknown Identity Provider -->
             <xsl:otherwise>
                 <xsl:message terminate="yes">Error: Unknown Identity Provider '<xsl:value-of select="$idp"/>'</xsl:message>
             </xsl:otherwise>

--- a/etc/services/cas.json
+++ b/etc/services/cas.json
@@ -3,7 +3,7 @@
   "id" : 983219871349823,
   "name" : "",
   "description" : "",
-  "serviceId" : "^https?://(localhost|127.0.0.1|accounts.dev.osf.io)(|:8080|:8443)/.*",
+  "serviceId" : "^https?://(localhost|127.0.0.1|accounts.dev.osf.io|test-accounts.osf.io)(|:8080|:8443)/.*",
   "evaluationOrder": "2000",
   "logo": "",
   "attributeReleasePolicy" : {

--- a/etc/services/oauth2.json
+++ b/etc/services/oauth2.json
@@ -3,7 +3,7 @@
   "id" : 983450982340993434,
   "name" : "",
   "description" : "",
-  "serviceId" : "^https?://(localhost|127.0.0.1|accounts.dev.osf.io):(8443|8080)?/oauth2/callbackAuthorize",
+  "serviceId" : "^https?://(localhost|127.0.0.1|accounts.dev.osf.io|test-accounts.osf.io)(|:8080|:8443)?/oauth2/callbackAuthorize",
   "evaluationOrder": "1000",
   "properties" : {
     "@class": "java.util.HashMap",


### PR DESCRIPTION
### Purpose

Fix Wrong Query for Two-Factor Authentication.

This bug was introduced due to the fact that `osf_user.id` happen to equal to `addons_two_factor_user_settings.id` in my local database. However the correct query should be comparing `osf_user.id` and the `id` (PK) of `addons_two_factor_user_settings.owner_id` which is a foreign key references the user.

Please note that the code in diff is not raw Postgres Query. `owner_id INTEGER,`  is mapped to the foreign key `osf_user` object, so the query is `p where p.owner.id = :ownerId`.

```java
@Entity
@Table(name = "addons_twofactor_usersettings")
public class OpenScienceFrameworkTimeBasedOneTimePassword {
    ...
    @Id
    @Column(name = "id", nullable = false)
    private Integer id;

    @OneToOne
    @JoinColumn(name = "owner_id")
    private OpenScienceFrameworkUser owner;

    @Column(name = "totp_secret", nullable = false)
    private String totpSecret;

    @Column(name = "is_confirmed", nullable = false)
    private Boolean confirmed;

    @Column(name = "deleted", nullable = false)
    private Boolean deleted;
    ...
}
```