### PR TITLE
[Feature] CAS -->> GUID -->> OSF [#CAS-18]

### DIFF
--- a/cas-server-support-osf/src/main/java/io/cos/cas/adaptors/postgres/daos/OpenScienceFrameworkDao.java
+++ b/cas-server-support-osf/src/main/java/io/cos/cas/adaptors/postgres/daos/OpenScienceFrameworkDao.java
@@ -22,6 +22,7 @@ package io.cos.cas.adaptors.postgres.daos;
 import io.cos.cas.adaptors.postgres.models.OpenScienceFrameworkApiOauth2Application;
 import io.cos.cas.adaptors.postgres.models.OpenScienceFrameworkApiOauth2PersonalAccessToken;
 import io.cos.cas.adaptors.postgres.models.OpenScienceFrameworkApiOauth2Scope;
+import io.cos.cas.adaptors.postgres.models.OpenScienceFrameworkGuid;
 import io.cos.cas.adaptors.postgres.models.OpenScienceFrameworkInstitution;
 import io.cos.cas.adaptors.postgres.models.OpenScienceFrameworkTimeBasedOneTimePassword;
 import io.cos.cas.adaptors.postgres.models.OpenScienceFrameworkUser;
@@ -97,4 +98,12 @@ public interface OpenScienceFrameworkDao {
      * @return OpenScienceFrameworkApiOauth2Application List or null
      */
     List<OpenScienceFrameworkApiOauth2Application> findOauthApplications();
+
+    /**
+     * Find the GUID object asscociated with a User.
+     *
+     * @param user the user
+     * @return the GUID object
+     */
+    OpenScienceFrameworkGuid findGuidByUser(final OpenScienceFrameworkUser user);
 }

--- a/cas-server-support-osf/src/main/java/io/cos/cas/adaptors/postgres/daos/OpenScienceFrameworkDaoImpl.java
+++ b/cas-server-support-osf/src/main/java/io/cos/cas/adaptors/postgres/daos/OpenScienceFrameworkDaoImpl.java
@@ -194,7 +194,7 @@ public class OpenScienceFrameworkDaoImpl implements OpenScienceFrameworkDao {
     public OpenScienceFrameworkGuid findGuidByUser(final OpenScienceFrameworkUser user) {
         try {
             final TypedQuery<OpenScienceFrameworkGuid> query = entityManager.createQuery(
-                    "select g from OpenScienceFrameworkGUID g where"
+                    "select g from OpenScienceFrameworkGuid g where"
                     + " g.objectId = :userId"
                     + " and g.djangoContentType.appLabel = :appLable"
                     + " and g.djangoContentType.model = :model",

--- a/cas-server-support-osf/src/main/java/io/cos/cas/adaptors/postgres/daos/OpenScienceFrameworkDaoImpl.java
+++ b/cas-server-support-osf/src/main/java/io/cos/cas/adaptors/postgres/daos/OpenScienceFrameworkDaoImpl.java
@@ -22,6 +22,7 @@ package io.cos.cas.adaptors.postgres.daos;
 import io.cos.cas.adaptors.postgres.models.OpenScienceFrameworkApiOauth2Application;
 import io.cos.cas.adaptors.postgres.models.OpenScienceFrameworkApiOauth2PersonalAccessToken;
 import io.cos.cas.adaptors.postgres.models.OpenScienceFrameworkApiOauth2Scope;
+import io.cos.cas.adaptors.postgres.models.OpenScienceFrameworkGuid;
 import io.cos.cas.adaptors.postgres.models.OpenScienceFrameworkInstitution;
 import io.cos.cas.adaptors.postgres.models.OpenScienceFrameworkTimeBasedOneTimePassword;
 import io.cos.cas.adaptors.postgres.models.OpenScienceFrameworkUser;
@@ -183,6 +184,26 @@ public class OpenScienceFrameworkDaoImpl implements OpenScienceFrameworkDao {
                     OpenScienceFrameworkApiOauth2Application.class
             );
             return query.getResultList();
+        } catch (final PersistenceException e) {
+            LOGGER.error(e.toString());
+            return null;
+        }
+    }
+
+    @Override
+    public OpenScienceFrameworkGuid findGuidByUser(final OpenScienceFrameworkUser user) {
+        try {
+            final TypedQuery<OpenScienceFrameworkGuid> query = entityManager.createQuery(
+                    "select g from OpenScienceFrameworkGUID g where"
+                    + " g.objectId = :userId"
+                    + " and g.djangoContentType.appLabel = :appLable"
+                    + " and g.djangoContentType.model = :model",
+                    OpenScienceFrameworkGuid.class
+            );
+            query.setParameter("userId", user.getId());
+            query.setParameter("appLable", "osf");
+            query.setParameter("model", "osfuser");
+            return query.getSingleResult();
         } catch (final PersistenceException e) {
             LOGGER.error(e.toString());
             return null;

--- a/cas-server-support-osf/src/main/java/io/cos/cas/adaptors/postgres/handlers/OpenScienceFrameworkAuthenticationHandler.java
+++ b/cas-server-support-osf/src/main/java/io/cos/cas/adaptors/postgres/handlers/OpenScienceFrameworkAuthenticationHandler.java
@@ -25,6 +25,7 @@ import java.security.MessageDigest;
 import java.util.HashMap;
 import java.util.Map;
 
+import io.cos.cas.adaptors.postgres.models.OpenScienceFrameworkGuid;
 import io.cos.cas.adaptors.postgres.models.OpenScienceFrameworkTimeBasedOneTimePassword;
 import io.cos.cas.adaptors.postgres.models.OpenScienceFrameworkUser;
 import io.cos.cas.adaptors.postgres.daos.OpenScienceFrameworkDaoImpl;
@@ -194,8 +195,12 @@ public class OpenScienceFrameworkAuthenticationHandler extends AbstractPreAndPos
         attributes.put("givenName", user.getGivenName());
         attributes.put("familyName", user.getFamilyName());
 
+
+        final OpenScienceFrameworkGuid guid = openScienceFrameworkDao.findGuidByUser(user);
+        return createHandlerResult(credential, this.principalFactory.createPrincipal(guid.getGuid(), attributes), null);
+
         // CAS returns the user's postgres primary key string to OSF
-        return createHandlerResult(credential, this.principalFactory.createPrincipal(user.getId().toString(), attributes), null);
+//        return createHandlerResult(credential, this.principalFactory.createPrincipal(user.getId().toString(), attributes), null);
     }
 
     /**

--- a/cas-server-support-osf/src/main/java/io/cos/cas/adaptors/postgres/handlers/OpenScienceFrameworkAuthenticationHandler.java
+++ b/cas-server-support-osf/src/main/java/io/cos/cas/adaptors/postgres/handlers/OpenScienceFrameworkAuthenticationHandler.java
@@ -195,12 +195,10 @@ public class OpenScienceFrameworkAuthenticationHandler extends AbstractPreAndPos
         attributes.put("givenName", user.getGivenName());
         attributes.put("familyName", user.getFamilyName());
 
-
+        // CAS returns the user's GUID to OSF
+        // Note: GUID is recommended. Do not use user's pimary key or username.
         final OpenScienceFrameworkGuid guid = openScienceFrameworkDao.findGuidByUser(user);
         return createHandlerResult(credential, this.principalFactory.createPrincipal(guid.getGuid(), attributes), null);
-
-        // CAS returns the user's postgres primary key string to OSF
-//        return createHandlerResult(credential, this.principalFactory.createPrincipal(user.getId().toString(), attributes), null);
     }
 
     /**

--- a/cas-server-support-osf/src/main/java/io/cos/cas/adaptors/postgres/handlers/OpenScienceFrameworkPersonalAccessTokenHandler.java
+++ b/cas-server-support-osf/src/main/java/io/cos/cas/adaptors/postgres/handlers/OpenScienceFrameworkPersonalAccessTokenHandler.java
@@ -21,6 +21,7 @@ package io.cos.cas.adaptors.postgres.handlers;
 
 import io.cos.cas.adaptors.postgres.daos.OpenScienceFrameworkDaoImpl;
 import io.cos.cas.adaptors.postgres.models.OpenScienceFrameworkApiOauth2PersonalAccessToken;
+import io.cos.cas.adaptors.postgres.models.OpenScienceFrameworkGuid;
 import org.jasig.cas.support.oauth.personal.PersonalAccessToken;
 import org.jasig.cas.support.oauth.personal.handler.support.AbstractPersonalAccessTokenHandler;
 import org.slf4j.Logger;
@@ -62,11 +63,20 @@ public class OpenScienceFrameworkPersonalAccessTokenHandler extends AbstractPers
 
     @Override
     public PersonalAccessToken getToken(final String tokenId) {
-        final OpenScienceFrameworkApiOauth2PersonalAccessToken token = openScienceFrameworkDao.findOnePersonalAccessTokenByTokenId(tokenId);
+        final OpenScienceFrameworkApiOauth2PersonalAccessToken token
+            = openScienceFrameworkDao.findOnePersonalAccessTokenByTokenId(tokenId);
         if (token == null || !token.isActive()) {
             return null;
         }
         final String scopes = token.getScopes() == null ? "" : token.getScopes();
-        return new PersonalAccessToken(token.getTokenId(), token.getOwner().getUsername(), new HashSet<>(Arrays.asList(scopes.split(" "))));
+        final OpenScienceFrameworkGuid guid = openScienceFrameworkDao.findGuidByUser(token.getOwner());
+        if (guid == null) {
+            return null;
+        }
+        return new PersonalAccessToken(
+            token.getTokenId(),
+            guid.getGuid(),
+            new HashSet<>(Arrays.asList(scopes.split(" ")))
+        );
     }
 }

--- a/cas-server-support-osf/src/main/java/io/cos/cas/adaptors/postgres/models/OpenScienceFrameworkDjangoContentTypeId.java
+++ b/cas-server-support-osf/src/main/java/io/cos/cas/adaptors/postgres/models/OpenScienceFrameworkDjangoContentTypeId.java
@@ -1,0 +1,56 @@
+package io.cos.cas.adaptors.postgres.models;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Table;
+
+/**
+ * The Open Science Framework GUID.
+ *
+ * @author Longze Chen
+ * @since 4.1.0
+ */
+@Entity
+@Table(name = "django_content_type")
+public class OpenScienceFrameworkDjangoContentTypeId {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(OpenScienceFrameworkDjangoContentTypeId.class);
+
+    /** The Primary Key. */
+    @Id
+    @Column(name = "id", nullable = false)
+    private Integer id;
+
+    /** The Application Label. */
+    @Column(name = "app_label", nullable = false)
+    private String appLabel;
+
+    /** The Model Name. */
+    @Column(name = "model", nullable = false)
+    private String model;
+
+    /** Default Constructor. */
+    public OpenScienceFrameworkDjangoContentTypeId() {}
+
+    public Integer getId() {
+        return id;
+    }
+
+    public String getAppLabel() {
+        return appLabel;
+    }
+
+    public String getModel() {
+        return model;
+    }
+
+    @Override
+    public String toString() {
+        return String.format("%s_%s", appLabel, model);
+    }
+}
+

--- a/cas-server-support-osf/src/main/java/io/cos/cas/adaptors/postgres/models/OpenScienceFrameworkGuid.java
+++ b/cas-server-support-osf/src/main/java/io/cos/cas/adaptors/postgres/models/OpenScienceFrameworkGuid.java
@@ -1,0 +1,79 @@
+package io.cos.cas.adaptors.postgres.models;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.OneToOne;
+import javax.persistence.Table;
+import javax.persistence.Temporal;
+import javax.persistence.TemporalType;
+import java.util.Date;
+
+/**
+ * The Open Science Framework GUID.
+ *
+ * @author Longze Chen
+ * @since 4.1.0
+ */
+@Entity
+@Table(name = "osf_guid")
+public class OpenScienceFrameworkGuid {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(OpenScienceFrameworkGuid.class);
+
+    /** The Primary Key. */
+    @Id
+    @Column(name = "id", nullable = false)
+    private Integer id;
+
+    /** The GUID of the Object. */
+    @Column(name = "_id", nullable = false)
+    private String guid;
+
+    /** The Primary Key of the Object. */
+    @Column(name = "object_id", nullable = false)
+    private Integer objectId;
+
+    /** The Content Type of the Object. */
+    @OneToOne
+    @JoinColumn(name = "content_type_id")
+    private OpenScienceFrameworkDjangoContentTypeId djangoContentType;
+
+    /** The Date Created. */
+    @Temporal(TemporalType.TIMESTAMP)
+    @Column(name = "created", nullable = false)
+    private Date created;
+
+    /** The Default Constructor. */
+    public OpenScienceFrameworkGuid() {}
+
+    public Integer getId() {
+        return id;
+    }
+
+    public String getGuid() {
+        return guid;
+    }
+
+    public Integer getObjectId() {
+        return objectId;
+    }
+
+    public OpenScienceFrameworkDjangoContentTypeId getDjangoContentType() {
+        return djangoContentType;
+    }
+
+    @Override
+    public String toString() {
+        return String.format(
+            "OpenScienceFrameworkGuid [guid=%s, objectId=%d, djangoContentTypeId=%s]",
+            guid,
+            objectId,
+            djangoContentType.getId()
+        );
+    }
+}

--- a/cas-server-webapp/src/main/webapp/WEB-INF/view/jsp/default/ui/includes/bottom.jsp
+++ b/cas-server-webapp/src/main/webapp/WEB-INF/view/jsp/default/ui/includes/bottom.jsp
@@ -84,7 +84,7 @@
     </div> --%>
     <div class="copyright">
         <div class="row">
-            <p>Copyright &copy; 2011-2016 <a href="https://cos.io">Center for Open Science</a> |
+            <p>Copyright &copy; 2011-2017 <a href="https://cos.io">Center for Open Science</a> |
                 <a href="https://github.com/CenterForOpenScience/centerforopenscience.org/blob/master/TERMS_OF_USE.md">Terms of Use</a> |
                 <a href="https://github.com/CenterForOpenScience/centerforopenscience.org/blob/master/PRIVACY_POLICY.md">Privacy Policy</a>
             </p>


### PR DESCRIPTION
During service validation and oauth2 authorization, CAS should returns the unique GUID of the user instead of using the primary key id or the email username.

### Side Effects:

- [ ] Existing AT and PAT on CAS side breaks. Clear them and let CAS regenerate them upon new request. **This does not affect production but affects staging 3.**

### Deployment Notes

- [x] Must be deployed at the same time with CAS PR: https://github.com/CenterForOpenScience/osf.io/pull/6745

### Tickets

https://openscience.atlassian.net/browse/CAS-18