### PR TITLE
[Feature] Port Recent Changes to Django-OSF [No Ticket]

### DIFF
--- a/cas-server-support-osf/src/main/java/io/cos/cas/adaptors/postgres/handlers/OpenScienceFrameworkAuthenticationHandler.java
+++ b/cas-server-support-osf/src/main/java/io/cos/cas/adaptors/postgres/handlers/OpenScienceFrameworkAuthenticationHandler.java
@@ -235,6 +235,7 @@ public class OpenScienceFrameworkAuthenticationHandler extends AbstractPreAndPos
         // An active user must be registered, claimed, not disabled, not merged and has a not null/None password.
         // Only active user can pass the verification.
         if (user.isActive()) {
+            logger.info("User Status Check: {}", USER_ACTIVE);
             return USER_ACTIVE;
         } else {
             // If the user instance is not claimed, it is also not registered and not confirmed.
@@ -242,10 +243,12 @@ public class OpenScienceFrameworkAuthenticationHandler extends AbstractPreAndPos
             if (!user.isClaimed() && !user.isRegistered() && !user.isConfirmed()) {
                 if (isUnusablePassword(user.getPassword())) {
                     // If the user instance has an unusable password, it must be an unclaimed contributor.
+                    logger.info("User Status Check: {}", USER_NOT_CLAIMED);
                     return USER_NOT_CLAIMED;
                 } else if (checkPasswordPrefix(user.getPassword())) {
                     // If the user instance has a password with a valid prefix, it must be a unconfirmed user who
                     // has registered for a new account.
+                    logger.info("User Status Check: {}", USER_NOT_CONFIRMED);
                     return USER_NOT_CONFIRMED;
                 }
             }
@@ -253,6 +256,7 @@ public class OpenScienceFrameworkAuthenticationHandler extends AbstractPreAndPos
             // `.merged_by` field being not null is a sufficient condition.
             // However, its username is set to GUID and password is set to unusable.
             if (user.isMerged()) {
+                logger.info("User Status Check: {}", USER_MERGED);
                 return USER_MERGED;
             }
             // If the user instance is disabled, it is also not registered but claimed.
@@ -260,10 +264,12 @@ public class OpenScienceFrameworkAuthenticationHandler extends AbstractPreAndPos
             // However, it still has the username and password.
             // When the user tries to login, an account disabled message will be displayed.
             if (user.isDisabled()) {
+                logger.info("User Status Check: {}", USER_DISABLED);
                 return USER_DISABLED;
             }
 
             // Other status combinations are considered UNKNOWN
+            logger.info("User Status Check: {}", USER_STATUS_UNKNOWN);
             return USER_STATUS_UNKNOWN;
         }
     }

--- a/cas-server-support-osf/src/main/java/io/cos/cas/authentication/ShouldNotHappenException.java
+++ b/cas-server-support-osf/src/main/java/io/cos/cas/authentication/ShouldNotHappenException.java
@@ -21,19 +21,22 @@ package io.cos.cas.authentication;
 import javax.security.auth.login.AccountException;
 
 /**
- * Describes an error condition where authentication occurs from an registered but not confirmed account.
+ * Describes an error condition where authentication occurs from an account that:
+ * 1. unclaimed user which is created as an contributor
+ * 2. merged user which is merged into antoher account
+ * 3. other undefined user status (inactive and unknown)
  *
- * @author Michael Haselton
+ * @author Longze Chen
  * @since 4.1.0
  */
-public class LoginNotAllowedException extends AccountException {
+public class ShouldNotHappenException extends AccountException {
 
-    private static final long serialVersionUID = 3376259469680697722L;
+    private static final long serialVersionUID = 3376259469680697723L;
 
     /**
      * Instantiates a new invalid login location exception.
      */
-    public LoginNotAllowedException() {
+    public ShouldNotHappenException() {
         super();
     }
 
@@ -42,7 +45,7 @@ public class LoginNotAllowedException extends AccountException {
      *
      * @param message the message
      */
-    public LoginNotAllowedException(final String message) {
+    public ShouldNotHappenException(final String message) {
         super(message);
     }
 }

--- a/cas-server-support-osf/src/main/java/io/cos/cas/authentication/ShouldNotHappenException.java
+++ b/cas-server-support-osf/src/main/java/io/cos/cas/authentication/ShouldNotHappenException.java
@@ -21,19 +21,22 @@ package io.cos.cas.authentication;
 import javax.security.auth.login.AccountException;
 
 /**
- * Describes an error condition where authentication occurs from an registered but not confirmed account.
+ * Describes an error condition where authentication occurs from an account that:
+ * 1. unclaimed user which is created as an contributor
+ * 2. merged user which is merged into antoher account
+ * 3. other undefined user status (inactive and unknown)
  *
- * @author Michael Haselton
+ * @author Longze Chen
  * @since 4.1.0
  */
-public class LoginNotAllowedException extends AccountException {
+public class ShouldNotHappenException extends AccountException {
 
-    private static final long serialVersionUID = 3376259469680697722L;
+    private static final long serialVersionUID = 8296529645368130304L;
 
     /**
      * Instantiates a new invalid login location exception.
      */
-    public LoginNotAllowedException() {
+    public ShouldNotHappenException() {
         super();
     }
 
@@ -42,7 +45,7 @@ public class LoginNotAllowedException extends AccountException {
      *
      * @param message the message
      */
-    public LoginNotAllowedException(final String message) {
+    public ShouldNotHappenException(final String message) {
         super(message);
     }
 }

--- a/cas-server-support-osf/src/main/java/io/cos/cas/authentication/ShouldNotHappenException.java
+++ b/cas-server-support-osf/src/main/java/io/cos/cas/authentication/ShouldNotHappenException.java
@@ -31,7 +31,7 @@ import javax.security.auth.login.AccountException;
  */
 public class ShouldNotHappenException extends AccountException {
 
-    private static final long serialVersionUID = 3376259469680697723L;
+    private static final long serialVersionUID = 8296529645368130304L;
 
     /**
      * Instantiates a new invalid login location exception.

--- a/cas-server-support-osf/src/main/java/io/cos/cas/web/flow/OpenScienceFrameworkAuthenticationExceptionHandler.java
+++ b/cas-server-support-osf/src/main/java/io/cos/cas/web/flow/OpenScienceFrameworkAuthenticationExceptionHandler.java
@@ -25,6 +25,7 @@ import io.cos.cas.authentication.LoginNotAllowedException;
 import io.cos.cas.authentication.OneTimePasswordFailedLoginException;
 import io.cos.cas.authentication.OneTimePasswordRequiredException;
 import io.cos.cas.authentication.RemoteUserFailedLoginException;
+import io.cos.cas.authentication.ShouldNotHappenException;
 import org.jasig.cas.web.flow.AuthenticationExceptionHandler;
 
 /**
@@ -49,6 +50,7 @@ public class OpenScienceFrameworkAuthenticationExceptionHandler extends Authenti
         DEFAULT_ERROR_LIST.add(org.jasig.cas.authentication.InvalidLoginTimeException.class);
         // Open Science Framework Exceptions
         DEFAULT_ERROR_LIST.add(LoginNotAllowedException.class);
+        DEFAULT_ERROR_LIST.add(ShouldNotHappenException.class);
         DEFAULT_ERROR_LIST.add(RemoteUserFailedLoginException.class);
         // One Time Password Exceptions
         DEFAULT_ERROR_LIST.add(OneTimePasswordFailedLoginException.class);

--- a/cas-server-webapp/src/main/resources/messages.properties
+++ b/cas-server-webapp/src/main/resources/messages.properties
@@ -111,8 +111,6 @@ Applications that wish to authenticate with CAS must explicitly be defined in th
 # Password policy
 password.expiration.warning=Your password expires in {0} day(s). Please <a href="{1}">change your password</a> now.
 password.expiration.loginsRemaining=You have {0} login(s) remaining before you <strong>MUST</strong> change your password.
-screen.accountdisabled.heading=This account has been disabled.
-screen.accountdisabled.message=Please contact <a href="mailto:support@osf.io">support@osf.io</a> to regain access.
 screen.accountlocked.heading=This account has been locked.
 screen.accountlocked.message=Please contact <a href="mailto:support@osf.io">support@osf.io</a> to regain access.
 screen.expiredpass.heading=Your password has expired.
@@ -123,9 +121,16 @@ screen.badhours.heading=Your account is forbidden to login at this time.
 screen.badhours.message=Please try again later.
 screen.badworkstation.heading=You cannot login from this workstation.
 screen.badworkstation.message=Please contact <a href="mailto:support@osf.io">support@osf.io</a> to regain access.
-# Open Science Framework
-screen.loginnotallowed.heading=Account has not been confirmed.
+
+# Open Science Framework Login Failure Pages
+screen.loginnotallowed.heading=Account Not Confirmed
 screen.loginnotallowed.message=This login email has been registered but not confirmed. Please check your email (and spam folder). <a href="{0}">Click here</a> to resend your confirmation email.
+screen.accountdisabled.heading=Account Disabled
+screen.accountdisabled.message=This account has been disabled. Please contact <a href="mailto:support@osf.io">support@osf.io</a> to regain access.
+screen.shouldnothappen.heading=Account Not Active
+screen.shouldnothappen.message=Cannot login to an inactive account. If you believe this should not happen, please contact <a href="mailto:support@osf.io">support@osf.io</a>.
+
+# Institution Login Failure Page
 screen.remoteuserfailedlogin.heading=Institution Login Failure
 screen.remoteuserfailedlogin.message=Please check with your Institution to verify your account is entitled to authenticate to the Open Science Framework.
 

--- a/cas-server-webapp/src/main/webapp/WEB-INF/view/jsp/default/ui/casAccountDisabledView.jsp
+++ b/cas-server-webapp/src/main/webapp/WEB-INF/view/jsp/default/ui/casAccountDisabledView.jsp
@@ -20,11 +20,10 @@
 --%>
 <jsp:directive.include file="includes/top.jsp" />
 
-  <div id="msg" class="errors">
-    <spring:eval var="osfResendConfirmationUrl" expression="@casProperties.getProperty('osf.resendConfirmation.url')" />
-    <h2><spring:message code="screen.loginnotallowed.heading" /></h2>
-    <p><spring:message code="screen.loginnotallowed.message" arguments="${osfResendConfirmationUrl}" /></p>
-  </div>
+<div id="msg" class="errors">
+    <h2><spring:message code="screen.accountdisabled.heading" /></h2>
+    <p><spring:message code="screen.accountdisabled.message" /></p>
+</div>
 
 <c:set var="alternativeBottomLogin" value="true"/>
 

--- a/cas-server-webapp/src/main/webapp/WEB-INF/view/jsp/default/ui/casOtpLoginView.jsp
+++ b/cas-server-webapp/src/main/webapp/WEB-INF/view/jsp/default/ui/casOtpLoginView.jsp
@@ -29,23 +29,20 @@
 </c:if>
 
 <c:if test="${not empty registeredService}">
-    <%-- <c:set var="registeredServiceLogo" value="images/webapp.png"/> --%>
-    <c:if test="${not empty registeredService.logo}">
-        <c:set var="registeredServiceLogo" value="${registeredService.logo}"/>
-    </c:if>
-
     <c:if test="${not empty registeredService.logo || not empty registeredService.name}">
-        <div id="serviceui" class="serviceinfo">
+        <div id="service-ui" class="service-info">
             <table>
                 <tr>
-                    <c:if test="${not empty registeredService.logo}">
-                        <td><img src="${registeredServiceLogo}"></td>
+                    <c:if test="${not empty registeredService.logo && empty registeredService.name}">
+                        <td><img class="service-logo-full" src="${registeredService.logo}"> </td>
                     </c:if>
-                    <c:if test="${not empty registeredService.name}">
-                        <td id="servicedesc">
-                            <h1>${fn:escapeXml(registeredService.name)}</h1>
-                            <p>${fn:escapeXml(registeredService.description)}</p>
-                        </td>
+                    <c:if test="${empty registeredService.logo && not empty registeredService.name}">
+                        <td><span class="service-name">${registeredService.name}</span></td>
+                    </c:if>
+                    <c:if test="${not empty registeredService.logo && not empty registeredService.name}">
+                        <td><img id="service-logo" class="service-logo-${registeredService.name}" src="${registeredService.logo}"> </td>
+                        <td>&nbsp;&nbsp;&nbsp;</td>
+                        <td><span class="service-name">${registeredService.name} Preprints</span></td>
                     </c:if>
                 </tr>
             </table>
@@ -100,4 +97,7 @@
         </section> --%>
     </form:form>
 </div>
+
+<c:set var="alternativeBottomNone" value="true"/>
+
 <jsp:directive.include file="includes/bottom.jsp" />

--- a/cas-server-webapp/src/main/webapp/WEB-INF/view/jsp/default/ui/casRemoteUserFailedLoginView.jsp
+++ b/cas-server-webapp/src/main/webapp/WEB-INF/view/jsp/default/ui/casRemoteUserFailedLoginView.jsp
@@ -19,8 +19,12 @@
 
 --%>
 <jsp:directive.include file="includes/top.jsp" />
+
   <div id="msg" class="errors">
     <h2><spring:message code="screen.remoteuserfailedlogin.heading" /></h2>
     <p><spring:message code="screen.remoteuserfailedlogin.message" /></p>
   </div>
+
+<c:set var="alternativeBottomLogin" value="true"/>
+
 <jsp:directive.include file="includes/bottom.jsp" />

--- a/cas-server-webapp/src/main/webapp/WEB-INF/view/jsp/default/ui/casRemoteUserFailedLoginView.jsp
+++ b/cas-server-webapp/src/main/webapp/WEB-INF/view/jsp/default/ui/casRemoteUserFailedLoginView.jsp
@@ -23,4 +23,5 @@
     <h2><spring:message code="screen.remoteuserfailedlogin.heading" /></h2>
     <p><spring:message code="screen.remoteuserfailedlogin.message" /></p>
   </div>
+<c:set var="alternativeBottomLogin" value="true"/>
 <jsp:directive.include file="includes/bottom.jsp" />

--- a/cas-server-webapp/src/main/webapp/WEB-INF/view/jsp/default/ui/casShouldNotHappenView.jsp
+++ b/cas-server-webapp/src/main/webapp/WEB-INF/view/jsp/default/ui/casShouldNotHappenView.jsp
@@ -20,11 +20,10 @@
 --%>
 <jsp:directive.include file="includes/top.jsp" />
 
-  <div id="msg" class="errors">
-    <spring:eval var="osfResendConfirmationUrl" expression="@casProperties.getProperty('osf.resendConfirmation.url')" />
-    <h2><spring:message code="screen.loginnotallowed.heading" /></h2>
-    <p><spring:message code="screen.loginnotallowed.message" arguments="${osfResendConfirmationUrl}" /></p>
-  </div>
+<div id="msg" class="errors">
+    <h2><spring:message code="screen.shouldnothappen.heading" /></h2>
+    <p><spring:message code="screen.shouldnothappen.message" /></p>
+</div>
 
 <c:set var="alternativeBottomLogin" value="true"/>
 

--- a/cas-server-webapp/src/main/webapp/WEB-INF/view/jsp/default/ui/includes/bottom.jsp
+++ b/cas-server-webapp/src/main/webapp/WEB-INF/view/jsp/default/ui/includes/bottom.jsp
@@ -84,7 +84,7 @@
     </div> --%>
     <div class="copyright">
         <div class="row">
-            <p>Copyright &copy; 2011-2016 <a href="https://cos.io">Center for Open Science</a> |
+            <p>Copyright &copy; 2011-2017 <a href="https://cos.io">Center for Open Science</a> |
                 <a href="https://github.com/CenterForOpenScience/centerforopenscience.org/blob/master/TERMS_OF_USE.md">Terms of Use</a> |
                 <a href="https://github.com/CenterForOpenScience/centerforopenscience.org/blob/master/PRIVACY_POLICY.md">Privacy Policy</a>
             </p>

--- a/cas-server-webapp/src/main/webapp/WEB-INF/view/jsp/default/ui/includes/bottom.jsp
+++ b/cas-server-webapp/src/main/webapp/WEB-INF/view/jsp/default/ui/includes/bottom.jsp
@@ -31,7 +31,7 @@
                 </c:when>
                 <c:when test="${not empty alternativeBottomLogin}">
                     <spring:eval var="osfLoginUrl" expression="@casProperties.getProperty('cas.osf.login.url')" />
-                    <a id="alternative-osf" href="${osfLoginUrl}">Sign In</a>&nbsp;&nbsp;&nbsp;&nbsp;
+                    <a id="alternative-osf" href="${osfLoginUrl}service=${osfLoginContext.getServiceUrl()}">Sign In</a>&nbsp;&nbsp;&nbsp;&nbsp;
                 </c:when>
                 <c:otherwise>
                     <c:choose>

--- a/cas-server-webapp/src/main/webapp/WEB-INF/view/jsp/default/ui/includes/bottom.jsp
+++ b/cas-server-webapp/src/main/webapp/WEB-INF/view/jsp/default/ui/includes/bottom.jsp
@@ -21,57 +21,60 @@
 
 <%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
 
-
-    <div class="row" style="text-align: center;">
-        <hr><br>
-        <c:choose>
-            <c:when test="${not empty alternativeBottomLogout}">
-                <spring:eval var="casLogoutUrl" expression="@casProperties.getProperty('cas.logout.url')" />
-                <a id="alternative-osf" href="${casLogoutUrl}">Sign Out</a>&nbsp;&nbsp;&nbsp;&nbsp;
-            </c:when>
-            <c:when test="${not empty alternativeBottomLogin}">
-                <spring:eval var="osfLoginUrl" expression="@casProperties.getProperty('cas.osf.login.url')" />
-                <a id="alternative-osf" href="${osfLoginUrl}">Sign In</a>&nbsp;&nbsp;&nbsp;&nbsp;
-            </c:when>
-            <c:otherwise>
-                <c:choose>
-                    <c:when test="${osfLoginContext.isInstitutionLogin()}">
-                        <spring:eval var="osfLoginUrl" expression="@casProperties.getProperty('cas.osf.login.url')" />
-                        <c:choose>
-                            <c:when test="${osfLoginContext.isServiceUrl()}">
-                                <a id="alternative-osf" href="${osfLoginUrl}service=${osfLoginContext.getServiceUrl()}">Non-institution Login</a>&nbsp;&nbsp;&nbsp;&nbsp;
-                            </c:when>
-                            <c:otherwise>
-                                <a id="alternative-osf" href="${osfLoginUrl}">Non-institution Login</a>&nbsp;&nbsp;&nbsp;&nbsp;
-                            </c:otherwise>
-                        </c:choose>
-                    </c:when>
-                    <c:otherwise>
-                        <spring:eval var="institutionLoginUrl" expression="@casProperties.getProperty('cas.institution.login.url')" />
-                        <c:choose>
-                            <c:when test="${osfLoginContext.isServiceUrl()}">
-                                <a id="alternative-institution" href="${institutionLoginUrl}&service=${osfLoginContext.getServiceUrl()}">Login through Your Institution</a>&nbsp;&nbsp;&nbsp;&nbsp;
-                            </c:when>
-                            <c:otherwise>
-                                <a id="alternative-institution" href="${institutionLoginUrl}">Login through Your Institution</a>&nbsp;&nbsp;&nbsp;&nbsp;
-                            </c:otherwise>
-                        </c:choose>
-                    </c:otherwise>
-                </c:choose>
-            </c:otherwise>
-        </c:choose>
-        <spring:eval var="osfUrl" expression="@casProperties.getProperty('osf.url')" />
-        <a id="back-to-osf" href="${osfUrl}">Back&nbsp;to&nbsp;OSF</a><br>
-    </div>
+    <c:if test= "${empty alternativeBottomNone}">
+        <div class="row" style="text-align: center;">
+            <hr><br>
+            <c:choose>
+                <c:when test="${not empty alternativeBottomLogout}">
+                    <spring:eval var="casLogoutUrl" expression="@casProperties.getProperty('cas.logout.url')" />
+                    <a id="alternative-osf" href="${casLogoutUrl}">Sign Out</a>&nbsp;&nbsp;&nbsp;&nbsp;
+                </c:when>
+                <c:when test="${not empty alternativeBottomLogin}">
+                    <spring:eval var="osfLoginUrl" expression="@casProperties.getProperty('cas.osf.login.url')" />
+                    <a id="alternative-osf" href="${osfLoginUrl}">Sign In</a>&nbsp;&nbsp;&nbsp;&nbsp;
+                </c:when>
+                <c:otherwise>
+                    <c:choose>
+                        <c:when test="${osfLoginContext.isInstitutionLogin()}">
+                            <spring:eval var="osfLoginUrl" expression="@casProperties.getProperty('cas.osf.login.url')" />
+                            <c:choose>
+                                <c:when test="${osfLoginContext.isServiceUrl()}">
+                                    <a id="alternative-osf" href="${osfLoginUrl}service=${osfLoginContext.getServiceUrl()}">Non-institution Login</a>&nbsp;&nbsp;&nbsp;&nbsp;
+                                </c:when>
+                                <c:otherwise>
+                                    <a id="alternative-osf" href="${osfLoginUrl}">Non-institution Login</a>&nbsp;&nbsp;&nbsp;&nbsp;
+                                </c:otherwise>
+                            </c:choose>
+                        </c:when>
+                        <c:otherwise>
+                            <spring:eval var="institutionLoginUrl" expression="@casProperties.getProperty('cas.institution.login.url')" />
+                            <c:choose>
+                                <c:when test="${osfLoginContext.isServiceUrl()}">
+                                    <a id="alternative-institution" href="${institutionLoginUrl}&service=${osfLoginContext.getServiceUrl()}">Login through Your Institution</a>&nbsp;&nbsp;&nbsp;&nbsp;
+                                </c:when>
+                                <c:otherwise>
+                                    <a id="alternative-institution" href="${institutionLoginUrl}">Login through Your Institution</a>&nbsp;&nbsp;&nbsp;&nbsp;
+                                </c:otherwise>
+                            </c:choose>
+                        </c:otherwise>
+                    </c:choose>
+                </c:otherwise>
+            </c:choose>
+            <spring:eval var="osfUrl" expression="@casProperties.getProperty('osf.url')" />
+            <a id="back-to-osf" href="${osfUrl}">Back&nbsp;to&nbsp;OSF</a><br>
+        </div>
+    </c:if>
 
 </div> <!-- END #content -->
 
-<c:if test="${empty alternativeBottomLogout}">
-    <div class="row" style="text-align: center;">
-        <br>
-        <spring:eval var="createAccountUrl" expression="@casProperties.getProperty('osf.createAccount.url')" />
-        <a id="create-account" href="${createAccountUrl}${registeredService.properties.registerUrl.getValue()}">Create Account</a>
-    </div>
+<c:if test= "${empty alternativeBottomNone}">
+    <c:if test="${empty alternativeBottomLogout}">
+        <div class="row" style="text-align: center;">
+            <br>
+            <spring:eval var="createAccountUrl" expression="@casProperties.getProperty('osf.createAccount.url')" />
+            <a id="create-account" href="${createAccountUrl}${registeredService.properties.registerUrl.getValue()}">Create Account</a>
+        </div>
+    </c:if>
 </c:if>
 
 <footer>

--- a/cas-server-webapp/src/main/webapp/WEB-INF/webflow/login/login-webflow.xml
+++ b/cas-server-webapp/src/main/webapp/WEB-INF/webflow/login/login-webflow.xml
@@ -195,6 +195,7 @@
         <transition on="AccountNotFoundException" to="generateLoginTicket"/>
         <!-- Open Science Framework -->
         <transition on="LoginNotAllowedException" to="casLoginNotAllowedView" />
+        <transition on="ShouldNotHappenException" to="casShouldNotHappenView" />
         <transition on="RemoteUserFailedLoginException" to="casRemoteUserFailedLoginView" />
         <!-- One Time Password -->
         <transition on="OneTimePasswordRequiredException" to="casOtpLoginView"/>
@@ -268,6 +269,7 @@
     <end-state id="casBadHoursView" view="casBadHoursView"/>
     <end-state id="casBadWorkstationView" view="casBadWorkstationView"/>
     <end-state id="casLoginNotAllowedView" view="casLoginNotAllowedView" />
+    <end-state id="casShouldNotHappenView" view="casShouldNotHappenView" />
     <end-state id="casRemoteUserFailedLoginView" view="casRemoteUserFailedLoginView" />
 
     <end-state id="postView" view="postResponseView">


### PR DESCRIPTION
- [x] #31: [HotFix] Handle invalid user status and fix null password bug [#CAS-16] 
The main difference is Django's `unusable` password" replacing `null` password. In Django, an unusable password is generated instead of `null`, see [doc](https://docs.djangoproject.com/en/1.10/topics/auth/passwords/#module-django.contrib.auth.hashers). Here is how such a password is generated, see [code](https://docs.djangoproject.com/en/1.10/_modules/django/contrib/auth/hashers/#make_password).

- [x] #38 [HotFix] Remove Shibboleth Session Cookie [#CAS-28]
This fix applies to `feature/django-osf` without conflicts or modification.