### PR TITLE
[HotFix] Fix Raven Null Pointer Exception [CAS-85]

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -713,7 +713,7 @@
     <postgresql.version>9.4-1201-jdbc41</postgresql.version>
     <jstl.version>1.2</jstl.version>
     <servlet.api.version>3.0.1</servlet.api.version>
-    <raven.log4j2.version>7.8.0</raven.log4j2.version>
+    <raven.log4j2.version>7.8.2</raven.log4j2.version>
     <checkstyle.version>6.7</checkstyle.version>
     <apache.httpclient.version>4.4.1</apache.httpclient.version>
     <nimbus.jose.version>4.10</nimbus.jose.version>


### PR DESCRIPTION
### Ticket
https://openscience.atlassian.net/browse/CAS-85

### Fix
Upgrade `raven.log4j2` from `7.8.0` to `7.8.2`.
* 7.8.1 and above fix this issue
* 7.8.2 is what Apereo uses
Reference: https://github.com/getsentry/sentry-java/issues/272

### Note
Upgrade does fix the issue. However, I am not sure how much this helps us debugging since more logs takes the the place of the previous exception. @icereval 
* Before Upgrade:
```
2017-07-05 16:18:13,059 ERROR [com.getsentry.raven.servlet.RavenServletRequestListener] - <Error clearing RavenContext state.
java.lang.NullPointerException: No stored Raven instance is available to use. You must construct a Raven instance before using the static Raven methods.
	at com.getsentry.raven.Raven.getStoredInstance(Raven.java:208)
	at com.getsentry.raven.servlet.RavenServletRequestListener.requestDestroyed(RavenServletRequestListener.java:31)
	at org.eclipse.jetty.server.handler.ContextHandler.doHandle(ContextHandler.java:1135)
	at org.eclipse.jetty.servlet.ServletHandler.doScope(ServletHandler.java:511)
	at org.eclipse.jetty.server.session.SessionHandler.doScope(SessionHandler.java:185)
	at org.eclipse.jetty.server.handler.ContextHandler.doScope(ContextHandler.java:1055)
	at org.eclipse.jetty.server.handler.ScopedHandler.handle(ScopedHandler.java:141)
	at org.eclipse.jetty.server.handler.ContextHandlerCollection.handle(ContextHandlerCollection.java:213)
	at org.eclipse.jetty.server.handler.HandlerCollection.handle(HandlerCollection.java:109)
	at org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:118)
	at org.eclipse.jetty.server.Server.handle(Server.java:515)
	at org.eclipse.jetty.server.HttpChannel.handle(HttpChannel.java:291)
	at org.eclipse.jetty.server.HttpConnection.onFillable(HttpConnection.java:242)
	at org.eclipse.jetty.io.AbstractConnection$ReadCallback.succeeded(AbstractConnection.java:238)
	at org.eclipse.jetty.io.FillInterest.fillable(FillInterest.java:95)
	at org.eclipse.jetty.io.SelectChannelEndPoint$2.run(SelectChannelEndPoint.java:57)
	at org.eclipse.jetty.util.thread.strategy.ExecuteProduceConsume.produceAndRun(ExecuteProduceConsume.java:191)
	at org.eclipse.jetty.util.thread.strategy.ExecuteProduceConsume.run(ExecuteProduceConsume.java:126)
	at org.eclipse.jetty.util.thread.QueuedThreadPool.runJob(QueuedThreadPool.java:654)
	at org.eclipse.jetty.util.thread.QueuedThreadPool$3.run(QueuedThreadPool.java:572)
	at java.lang.Thread.run(Thread.java:745)
```
* After Upgrade
```
Jul 05, 2017 4:27:56 PM org.slf4j.impl.CasDelegatingLogger info
INFO: type=GAUGE, name=jvm.fd.usage, value=0.04912109375
Jul 05, 2017 4:27:56 PM org.slf4j.impl.CasDelegatingLogger info
INFO: type=GAUGE, name=jvm.gc.PS-MarkSweep.count, value=3
Jul 05, 2017 4:27:56 PM org.slf4j.impl.CasDelegatingLogger info
INFO: type=GAUGE, name=jvm.gc.PS-MarkSweep.time, value=372
Jul 05, 2017 4:27:56 PM org.slf4j.impl.CasDelegatingLogger info
INFO: type=GAUGE, name=jvm.gc.PS-Scavenge.count, value=13
Jul 05, 2017 4:27:56 PM org.slf4j.impl.CasDelegatingLogger info
INFO: type=GAUGE, name=jvm.gc.PS-Scavenge.time, value=399
Jul 05, 2017 4:27:56 PM org.slf4j.impl.CasDelegatingLogger info
INFO: type=GAUGE, name=jvm.memory.heap.committed, value=898105344
Jul 05, 2017 4:27:56 PM org.slf4j.impl.CasDelegatingLogger info
INFO: type=GAUGE, name=jvm.memory.heap.init, value=268435456
Jul 05, 2017 4:27:56 PM org.slf4j.impl.CasDelegatingLogger info
INFO: type=GAUGE, name=jvm.memory.heap.max, value=3817865216
Jul 05, 2017 4:27:56 PM org.slf4j.impl.CasDelegatingLogger info
INFO: type=GAUGE, name=jvm.memory.heap.usage, value=0.09743369002160185
Jul 05, 2017 4:27:56 PM org.slf4j.impl.CasDelegatingLogger info
INFO: type=GAUGE, name=jvm.memory.heap.used, value=371988696
Jul 05, 2017 4:27:56 PM org.slf4j.impl.CasDelegatingLogger info
INFO: type=GAUGE, name=jvm.memory.non-heap.committed, value=143589376
Jul 05, 2017 4:27:56 PM org.slf4j.impl.CasDelegatingLogger info
INFO: type=GAUGE, name=jvm.memory.non-heap.init, value=2555904
Jul 05, 2017 4:27:56 PM org.slf4j.impl.CasDelegatingLogger info
INFO: type=GAUGE, name=jvm.memory.non-heap.max, value=-1
Jul 05, 2017 4:27:56 PM org.slf4j.impl.CasDelegatingLogger info
INFO: type=GAUGE, name=jvm.memory.non-heap.usage, value=-1.41451528E8
Jul 05, 2017 4:27:56 PM org.slf4j.impl.CasDelegatingLogger info
INFO: type=GAUGE, name=jvm.memory.non-heap.used, value=141451528
Jul 05, 2017 4:27:56 PM org.slf4j.impl.CasDelegatingLogger info
INFO: type=GAUGE, name=jvm.memory.pools.Code-Cache.committed, value=32702464
Jul 05, 2017 4:27:56 PM org.slf4j.impl.CasDelegatingLogger info
INFO: type=GAUGE, name=jvm.memory.pools.Code-Cache.init, value=2555904
Jul 05, 2017 4:27:56 PM org.slf4j.impl.CasDelegatingLogger info
INFO: type=GAUGE, name=jvm.memory.pools.Code-Cache.max, value=251658240
Jul 05, 2017 4:27:56 PM org.slf4j.impl.CasDelegatingLogger info
INFO: type=GAUGE, name=jvm.memory.pools.Code-Cache.usage, value=0.12919769287109376
Jul 05, 2017 4:27:56 PM org.slf4j.impl.CasDelegatingLogger info
INFO: type=GAUGE, name=jvm.memory.pools.Code-Cache.used, value=32513664
Jul 05, 2017 4:27:56 PM org.slf4j.impl.CasDelegatingLogger info
INFO: type=GAUGE, name=jvm.memory.pools.Compressed-Class-Space.committed, value=12582912
Jul 05, 2017 4:27:56 PM org.slf4j.impl.CasDelegatingLogger info
INFO: type=GAUGE, name=jvm.memory.pools.Compressed-Class-Space.init, value=0
Jul 05, 2017 4:27:56 PM org.slf4j.impl.CasDelegatingLogger info
INFO: type=GAUGE, name=jvm.memory.pools.Compressed-Class-Space.max, value=1073741824
Jul 05, 2017 4:27:56 PM org.slf4j.impl.CasDelegatingLogger info
INFO: type=GAUGE, name=jvm.memory.pools.Compressed-Class-Space.usage, value=0.011326886713504791
Jul 05, 2017 4:27:56 PM org.slf4j.impl.CasDelegatingLogger info
INFO: type=GAUGE, name=jvm.memory.pools.Compressed-Class-Space.used, value=12162152
Jul 05, 2017 4:27:56 PM org.slf4j.impl.CasDelegatingLogger info
INFO: type=GAUGE, name=jvm.memory.pools.Metaspace.committed, value=98304000
Jul 05, 2017 4:27:56 PM org.slf4j.impl.CasDelegatingLogger info
INFO: type=GAUGE, name=jvm.memory.pools.Metaspace.init, value=0
Jul 05, 2017 4:27:56 PM org.slf4j.impl.CasDelegatingLogger info
INFO: type=GAUGE, name=jvm.memory.pools.Metaspace.max, value=-1
Jul 05, 2017 4:27:56 PM org.slf4j.impl.CasDelegatingLogger info
INFO: type=GAUGE, name=jvm.memory.pools.Metaspace.usage, value=0.9844534505208333
Jul 05, 2017 4:27:56 PM org.slf4j.impl.CasDelegatingLogger info
INFO: type=GAUGE, name=jvm.memory.pools.Metaspace.used, value=96775712
Jul 05, 2017 4:27:56 PM org.slf4j.impl.CasDelegatingLogger info
INFO: type=GAUGE, name=jvm.memory.pools.PS-Eden-Space.committed, value=663224320
Jul 05, 2017 4:27:56 PM org.slf4j.impl.CasDelegatingLogger info
INFO: type=GAUGE, name=jvm.memory.pools.PS-Eden-Space.init, value=67108864
Jul 05, 2017 4:27:56 PM org.slf4j.impl.CasDelegatingLogger info
INFO: type=GAUGE, name=jvm.memory.pools.PS-Eden-Space.max, value=1345847296
Jul 05, 2017 4:27:56 PM org.slf4j.impl.CasDelegatingLogger info
INFO: type=GAUGE, name=jvm.memory.pools.PS-Eden-Space.usage, value=0.21765441656762818
Jul 05, 2017 4:27:56 PM org.slf4j.impl.CasDelegatingLogger info
INFO: type=GAUGE, name=jvm.memory.pools.PS-Eden-Space.used, value=292929608
Jul 05, 2017 4:27:56 PM org.slf4j.impl.CasDelegatingLogger info
INFO: type=GAUGE, name=jvm.memory.pools.PS-Old-Gen.committed, value=193986560
Jul 05, 2017 4:27:56 PM org.slf4j.impl.CasDelegatingLogger info
INFO: type=GAUGE, name=jvm.memory.pools.PS-Old-Gen.init, value=179306496
Jul 05, 2017 4:27:56 PM org.slf4j.impl.CasDelegatingLogger info
INFO: type=GAUGE, name=jvm.memory.pools.PS-Old-Gen.max, value=2863661056
Jul 05, 2017 4:27:56 PM org.slf4j.impl.CasDelegatingLogger info
INFO: type=GAUGE, name=jvm.memory.pools.PS-Old-Gen.usage, value=0.015858485732747278
Jul 05, 2017 4:27:56 PM org.slf4j.impl.CasDelegatingLogger info
INFO: type=GAUGE, name=jvm.memory.pools.PS-Old-Gen.used, value=45413328
Jul 05, 2017 4:27:56 PM org.slf4j.impl.CasDelegatingLogger info
INFO: type=GAUGE, name=jvm.memory.pools.PS-Survivor-Space.committed, value=40894464
Jul 05, 2017 4:27:56 PM org.slf4j.impl.CasDelegatingLogger info
INFO: type=GAUGE, name=jvm.memory.pools.PS-Survivor-Space.init, value=11010048
Jul 05, 2017 4:27:56 PM org.slf4j.impl.CasDelegatingLogger info
INFO: type=GAUGE, name=jvm.memory.pools.PS-Survivor-Space.max, value=40894464
Jul 05, 2017 4:27:56 PM org.slf4j.impl.CasDelegatingLogger info
INFO: type=GAUGE, name=jvm.memory.pools.PS-Survivor-Space.usage, value=0.822746081229968
Jul 05, 2017 4:27:56 PM org.slf4j.impl.CasDelegatingLogger info
INFO: type=GAUGE, name=jvm.memory.pools.PS-Survivor-Space.used, value=33645760
Jul 05, 2017 4:27:56 PM org.slf4j.impl.CasDelegatingLogger info
INFO: type=GAUGE, name=jvm.memory.total.committed, value=1041694720
Jul 05, 2017 4:27:56 PM org.slf4j.impl.CasDelegatingLogger info
INFO: type=GAUGE, name=jvm.memory.total.init, value=270991360
Jul 05, 2017 4:27:56 PM org.slf4j.impl.CasDelegatingLogger info
INFO: type=GAUGE, name=jvm.memory.total.max, value=3817865215
Jul 05, 2017 4:27:56 PM org.slf4j.impl.CasDelegatingLogger info
INFO: type=GAUGE, name=jvm.memory.total.used, value=513447504
Jul 05, 2017 4:27:56 PM org.slf4j.impl.CasDelegatingLogger info
INFO: type=GAUGE, name=jvm.thread-states.blocked.count, value=0
Jul 05, 2017 4:27:56 PM org.slf4j.impl.CasDelegatingLogger info
INFO: type=GAUGE, name=jvm.thread-states.count, value=41
Jul 05, 2017 4:27:56 PM org.slf4j.impl.CasDelegatingLogger info
INFO: type=GAUGE, name=jvm.thread-states.daemon.count, value=17
Jul 05, 2017 4:27:56 PM org.slf4j.impl.CasDelegatingLogger info
INFO: type=GAUGE, name=jvm.thread-states.deadlock.count, value=0
Jul 05, 2017 4:27:56 PM org.slf4j.impl.CasDelegatingLogger info
INFO: type=GAUGE, name=jvm.thread-states.deadlocks, value=[]
Jul 05, 2017 4:27:56 PM org.slf4j.impl.CasDelegatingLogger info
INFO: type=GAUGE, name=jvm.thread-states.new.count, value=0
Jul 05, 2017 4:27:56 PM org.slf4j.impl.CasDelegatingLogger info
INFO: type=GAUGE, name=jvm.thread-states.runnable.count, value=6
Jul 05, 2017 4:27:56 PM org.slf4j.impl.CasDelegatingLogger info
INFO: type=GAUGE, name=jvm.thread-states.terminated.count, value=0
Jul 05, 2017 4:27:56 PM org.slf4j.impl.CasDelegatingLogger info
INFO: type=GAUGE, name=jvm.thread-states.timed_waiting.count, value=31
Jul 05, 2017 4:27:56 PM org.slf4j.impl.CasDelegatingLogger info
INFO: type=GAUGE, name=jvm.thread-states.waiting.count, value=4
Jul 05, 2017 4:27:56 PM org.slf4j.impl.CasDelegatingLogger info
INFO: type=METER, name=org.jasig.cas.CentralAuthenticationServiceImpl.CREATE_TICKET_GRANTING_TICKET_METER, count=0, mean_rate=0.0, m1=0.0, m5=0.0, m15=0.0, rate_unit=events/millisecond
Jul 05, 2017 4:27:56 PM org.slf4j.impl.CasDelegatingLogger info
INFO: type=METER, name=org.jasig.cas.CentralAuthenticationServiceImpl.DESTROY_TICKET_GRANTING_TICKET_METER, count=0, mean_rate=0.0, m1=0.0, m5=0.0, m15=0.0, rate_unit=events/millisecond
Jul 05, 2017 4:27:56 PM org.slf4j.impl.CasDelegatingLogger info
INFO: type=METER, name=org.jasig.cas.CentralAuthenticationServiceImpl.GET_TICKETS_METER, count=1, mean_rate=0.0, m1=0.0, m5=0.0, m15=0.0, rate_unit=events/millisecond
Jul 05, 2017 4:27:56 PM org.slf4j.impl.CasDelegatingLogger info
INFO: type=METER, name=org.jasig.cas.CentralAuthenticationServiceImpl.GET_TICKET_METER, count=0, mean_rate=0.0, m1=0.0, m5=0.0, m15=0.0, rate_unit=events/millisecond
Jul 05, 2017 4:27:56 PM org.slf4j.impl.CasDelegatingLogger info
INFO: type=METER, name=org.jasig.cas.CentralAuthenticationServiceImpl.GRANT_PROXY_GRANTING_TICKET_METER, count=0, mean_rate=0.0, m1=0.0, m5=0.0, m15=0.0, rate_unit=events/millisecond
Jul 05, 2017 4:27:56 PM org.slf4j.impl.CasDelegatingLogger info
INFO: type=METER, name=org.jasig.cas.CentralAuthenticationServiceImpl.GRANT_SERVICE_TICKET_METER, count=0, mean_rate=0.0, m1=0.0, m5=0.0, m15=0.0, rate_unit=events/millisecond
Jul 05, 2017 4:27:56 PM org.slf4j.impl.CasDelegatingLogger info
INFO: type=METER, name=org.jasig.cas.CentralAuthenticationServiceImpl.VALIDATE_SERVICE_TICKET_METER, count=0, mean_rate=0.0, m1=0.0, m5=0.0, m15=0.0, rate_unit=events/millisecond
Jul 05, 2017 4:27:56 PM org.slf4j.impl.CasDelegatingLogger info
INFO: type=METER, name=org.jasig.cas.support.oauth.CentralOAuthServiceImpl.GET_TOKEN_METER, count=0, mean_rate=0.0, m1=0.0, m5=0.0, m15=0.0, rate_unit=events/millisecond
Jul 05, 2017 4:27:56 PM org.slf4j.impl.CasDelegatingLogger info
INFO: type=TIMER, name=org.jasig.cas.CentralAuthenticationServiceImpl.CREATE_TICKET_GRANTING_TICKET_TIMER, count=0, min=0.0, max=0.0, mean=0.0, stddev=0.0, median=0.0, p75=0.0, p95=0.0, p98=0.0, p99=0.0, p999=0.0, mean_rate=0.0, m1=0.0, m5=0.0, m15=0.0, rate_unit=events/millisecond, duration_unit=milliseconds
Jul 05, 2017 4:27:56 PM org.slf4j.impl.CasDelegatingLogger info
INFO: type=TIMER, name=org.jasig.cas.CentralAuthenticationServiceImpl.DESTROY_TICKET_GRANTING_TICKET_TIMER, count=0, min=0.0, max=0.0, mean=0.0, stddev=0.0, median=0.0, p75=0.0, p95=0.0, p98=0.0, p99=0.0, p999=0.0, mean_rate=0.0, m1=0.0, m5=0.0, m15=0.0, rate_unit=events/millisecond, duration_unit=milliseconds
Jul 05, 2017 4:27:56 PM org.slf4j.impl.CasDelegatingLogger info
INFO: type=TIMER, name=org.jasig.cas.CentralAuthenticationServiceImpl.GET_TICKETS_TIMER, count=1, min=47.212838999999995, max=47.212838999999995, mean=47.212838999999995, stddev=0.0, median=47.212838999999995, p75=47.212838999999995, p95=47.212838999999995, p98=47.212838999999995, p99=47.212838999999995, p999=47.212838999999995, mean_rate=0.0, m1=0.0, m5=0.0, m15=0.0, rate_unit=events/millisecond, duration_unit=milliseconds
Jul 05, 2017 4:27:56 PM org.slf4j.impl.CasDelegatingLogger info
INFO: type=TIMER, name=org.jasig.cas.CentralAuthenticationServiceImpl.GET_TICKET_TIMER, count=0, min=0.0, max=0.0, mean=0.0, stddev=0.0, median=0.0, p75=0.0, p95=0.0, p98=0.0, p99=0.0, p999=0.0, mean_rate=0.0, m1=0.0, m5=0.0, m15=0.0, rate_unit=events/millisecond, duration_unit=milliseconds
Jul 05, 2017 4:27:56 PM org.slf4j.impl.CasDelegatingLogger info
INFO: type=TIMER, name=org.jasig.cas.CentralAuthenticationServiceImpl.GRANT_PROXY_GRANTING_TICKET_TIMER, count=0, min=0.0, max=0.0, mean=0.0, stddev=0.0, median=0.0, p75=0.0, p95=0.0, p98=0.0, p99=0.0, p999=0.0, mean_rate=0.0, m1=0.0, m5=0.0, m15=0.0, rate_unit=events/millisecond, duration_unit=milliseconds
Jul 05, 2017 4:27:56 PM org.slf4j.impl.CasDelegatingLogger info
INFO: type=TIMER, name=org.jasig.cas.CentralAuthenticationServiceImpl.GRANT_SERVICE_TICKET_TIMER, count=0, min=0.0, max=0.0, mean=0.0, stddev=0.0, median=0.0, p75=0.0, p95=0.0, p98=0.0, p99=0.0, p999=0.0, mean_rate=0.0, m1=0.0, m5=0.0, m15=0.0, rate_unit=events/millisecond, duration_unit=milliseconds
Jul 05, 2017 4:27:56 PM org.slf4j.impl.CasDelegatingLogger info
INFO: type=TIMER, name=org.jasig.cas.CentralAuthenticationServiceImpl.VALIDATE_SERVICE_TICKET_TIMER, count=0, min=0.0, max=0.0, mean=0.0, stddev=0.0, median=0.0, p75=0.0, p95=0.0, p98=0.0, p99=0.0, p999=0.0, mean_rate=0.0, m1=0.0, m5=0.0, m15=0.0, rate_unit=events/millisecond, duration_unit=milliseconds
Jul 05, 2017 4:27:56 PM org.slf4j.impl.CasDelegatingLogger info
INFO: type=TIMER, name=org.jasig.cas.support.oauth.CentralOAuthServiceImpl.GET_TOKEN_TIMER, count=0, min=0.0, max=0.0, mean=0.0, stddev=0.0, median=0.0, p75=0.0, p95=0.0, p98=0.0, p99=0.0, p999=0.0, mean_rate=0.0, m1=0.0, m5=0.0, m15=0.0, rate_unit=events/millisecond, duration_unit=milliseconds
```
