### PR TITLE
[HotFix] Verify `username` and `provider id` For Institution Authentication And Fix Share ORCiD Issue [CAS-86][CAS-87]

### DIFF
--- a/cas-server-support-osf/src/main/java/io/cos/cas/authentication/handler/support/OpenScienceFrameworkPrincipalFromRequestRemoteUserNonInteractiveCredentialsAction.java
+++ b/cas-server-support-osf/src/main/java/io/cos/cas/authentication/handler/support/OpenScienceFrameworkPrincipalFromRequestRemoteUserNonInteractiveCredentialsAction.java
@@ -469,7 +469,7 @@ public class OpenScienceFrameworkPrincipalFromRequestRemoteUserNonInteractiveCre
      * @throws ParserConfigurationException a parser configuration exception
      * @throws TransformerException a transformer exception
      */
-    private JSONObject normalizeRemotePrincipal(final OpenScienceFrameworkCredential credential)
+    protected JSONObject normalizeRemotePrincipal(final OpenScienceFrameworkCredential credential)
             throws ParserConfigurationException, TransformerException {
         final DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
         final DocumentBuilder builder = factory.newDocumentBuilder();

--- a/cas-server-support-osf/src/main/java/io/cos/cas/authentication/handler/support/OpenScienceFrameworkPrincipalFromRequestRemoteUserNonInteractiveCredentialsAction.java
+++ b/cas-server-support-osf/src/main/java/io/cos/cas/authentication/handler/support/OpenScienceFrameworkPrincipalFromRequestRemoteUserNonInteractiveCredentialsAction.java
@@ -399,6 +399,16 @@ public class OpenScienceFrameworkPrincipalFromRequestRemoteUserNonInteractiveCre
             final String username = provider.getJSONObject("user").getString("username");
             final String payload = normalizedPayload.toString();
 
+            if (institutionId == null || institutionId.trim().isEmpty()) {
+                logger.error("Notify Remote Principal Authenticated Exception: Institution Provider ID Required");
+                throw new RemoteUserFailedLoginException("Institution Provider ID Required");
+            }
+
+            if (username == null || username.trim().isEmpty()) {
+                logger.error("Notify Remote Principal Authenticated Exception: username=null, institution={}", institutionId);
+                throw new RemoteUserFailedLoginException("Username (Email) Required");
+            }
+
             logger.info("Notify Remote Principal Authenticated: username={}, institution={}", username, institutionId);
             logger.debug("Notify Remote Principal Authenticated [{}, {}] Normalized Payload '{}'", username, institutionId, payload);
 

--- a/cas-server-support-osf/src/test/java/io/cos/cas/mock/MockNormalizeRemotePrincipal.java
+++ b/cas-server-support-osf/src/test/java/io/cos/cas/mock/MockNormalizeRemotePrincipal.java
@@ -1,0 +1,38 @@
+package io.cos.cas.mock;
+
+import io.cos.cas.authentication.OpenScienceFrameworkCredential;
+
+import org.jasig.cas.CentralAuthenticationService;
+
+import org.json.JSONObject;
+
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.transform.TransformerException;
+
+/**
+ * This class mocks the {@link OpenScienceFrameworkPrincipalFromRequestRemoteUserNonInteractiveCredentialsAction} class.
+ *
+ * @author Longze Chen
+ * @since  4.1.5
+ */
+public class MockNormalizeRemotePrincipal extends MockOsfRemoteAuthenticateAction {
+
+    /** Constructor. */
+    public MockNormalizeRemotePrincipal(final CentralAuthenticationService centralAuthenticationService) {
+        super(centralAuthenticationService);
+    }
+
+    @Override
+    protected JSONObject normalizeRemotePrincipal(final OpenScienceFrameworkCredential credential)
+            throws ParserConfigurationException, TransformerException {
+
+        final JSONObject provider = new JSONObject();
+        final JSONObject user = new JSONObject();
+
+        user.put("username", credential.getUsername());
+        provider.put("id", credential.getInstitutionId());
+        provider.put("user", user);
+
+        return new JSONObject().put("provider", provider);
+    }
+}

--- a/cas-server-support-osf/src/test/java/io/cos/cas/mock/MockNotifyRemotePrincipalAuthenticated.java
+++ b/cas-server-support-osf/src/test/java/io/cos/cas/mock/MockNotifyRemotePrincipalAuthenticated.java
@@ -1,0 +1,28 @@
+package io.cos.cas.mock;
+
+import io.cos.cas.AbstractTestUtils;
+import io.cos.cas.authentication.OpenScienceFrameworkCredential;
+
+import org.jasig.cas.CentralAuthenticationService;
+
+import javax.security.auth.login.AccountException;
+
+/**
+ * This class mocks the {@link OpenScienceFrameworkPrincipalFromRequestRemoteUserNonInteractiveCredentialsAction} class.
+ *
+ * @author Longze Chen
+ * @since  4.1.5
+ */
+public class MockNotifyRemotePrincipalAuthenticated extends MockOsfRemoteAuthenticateAction {
+
+    /** Constructor. */
+    public MockNotifyRemotePrincipalAuthenticated(final CentralAuthenticationService centralAuthenticationService) {
+        super(centralAuthenticationService);
+    }
+
+    @Override
+    protected PrincipalAuthenticationResult notifyRemotePrincipalAuthenticated(
+            final OpenScienceFrameworkCredential credential) throws AccountException {
+        return new PrincipalAuthenticationResult(AbstractTestUtils.CONST_MAIL, AbstractTestUtils.CONST_INSTITUTION_ID);
+    }
+}

--- a/cas-server-support-osf/src/test/java/io/cos/cas/mock/MockOsfRemoteAuthenticateAction.java
+++ b/cas-server-support-osf/src/test/java/io/cos/cas/mock/MockOsfRemoteAuthenticateAction.java
@@ -1,11 +1,7 @@
 package io.cos.cas.mock;
 
-import io.cos.cas.AbstractTestUtils;
-import io.cos.cas.authentication.OpenScienceFrameworkCredential;
 import io.cos.cas.authentication.handler.support.OpenScienceFrameworkPrincipalFromRequestRemoteUserNonInteractiveCredentialsAction;
 import org.jasig.cas.CentralAuthenticationService;
-
-import javax.security.auth.login.AccountException;
 
 /**
  * This class mocks the {@link OpenScienceFrameworkPrincipalFromRequestRemoteUserNonInteractiveCredentialsAction} class.
@@ -16,10 +12,10 @@ import javax.security.auth.login.AccountException;
 public class MockOsfRemoteAuthenticateAction
     extends OpenScienceFrameworkPrincipalFromRequestRemoteUserNonInteractiveCredentialsAction {
 
-    private static final String INSTITUTION_AUTH_URL = "http://institutionauth/";
-    private static final String INSTITUTION_AUTH_JWE_SECRET = "osf_api_cas_login_jwe_secret_32b";
-    private static final String INSTITUTION_AUTH_JWT_SECRET = "osf_api_cas_login_jwt_secret_32b";
-    private static final String INSTITUTION_AUTH_XSL_LOCATION = "file:mock-institutions-auth.xsl";
+    protected static final String INSTITUTION_AUTH_URL = "http://institutionauth/";
+    protected static final String INSTITUTION_AUTH_JWE_SECRET = "osf_api_cas_login_jwe_secret_32b";
+    protected static final String INSTITUTION_AUTH_JWT_SECRET = "osf_api_cas_login_jwt_secret_32b";
+    protected static final String INSTITUTION_AUTH_XSL_LOCATION = "file:mock-institutions-auth.xsl";
 
     /** Constructor. */
     public MockOsfRemoteAuthenticateAction(
@@ -30,12 +26,5 @@ public class MockOsfRemoteAuthenticateAction
         this.setInstitutionsAuthJweSecret(INSTITUTION_AUTH_JWE_SECRET);
         this.setInstitutionsAuthJwtSecret(INSTITUTION_AUTH_JWT_SECRET);
         this.setInstitutionsAuthXslLocation(INSTITUTION_AUTH_XSL_LOCATION);
-    }
-
-    @Override
-    protected PrincipalAuthenticationResult notifyRemotePrincipalAuthenticated(
-            final OpenScienceFrameworkCredential credential
-    ) throws AccountException {
-        return new PrincipalAuthenticationResult(AbstractTestUtils.CONST_MAIL, AbstractTestUtils.CONST_INSTITUTION_ID);
     }
 }

--- a/cas-server-webapp/src/main/webapp/WEB-INF/view/jsp/default/ui/casLoginView.jsp
+++ b/cas-server-webapp/src/main/webapp/WEB-INF/view/jsp/default/ui/casLoginView.jsp
@@ -114,12 +114,8 @@
 
         <%-- TODO: Only display OAuth Client options for the OSF service, due to a limitation of our OAuth Provider implementation as it does not support non-existing OSF accounts. --%>
         <c:if test="${not empty registeredService}">
-            <c:if test="${not empty registeredService.id &&
-             registeredService.id == 983450982340993434 ||
-             registeredService.id == 203948234207230 || registeredService.id == 203948234207231 || registeredService.id == 203948234207232 ||
-             ( registeredService.id >= 203948234207240 && registeredService.id <= 203948234207253 ) || registeredService.id == 203948234207340}">
+            <c:if test="${not empty registeredService.id && ( registeredService.id == 203948234207230 || registeredService.id == 203948234207231 || registeredService.id == 203948234207232 || ( registeredService.id >= 203948234207240 && registeredService.id <= 203948234207253 ) || registeredService.id == 203948234207340 ) }">
                 <hr/>
-
                 <section class="row">
                     <a class="btn-oauth" href="${OrcidClientUrl}"><img class="orcid-logo" src="../images/orcid-logo.png"><spring:message code="screen.welcome.button.login.orcid" /></a>
                 </section>


### PR DESCRIPTION
### Ticket
https://openscience.atlassian.net/browse/CAS-86
https://openscience.atlassian.net/browse/CAS-87

![oauth-no-orcid](https://user-images.githubusercontent.com/3750414/28092649-386ef52a-6662-11e7-90b7-149c9679a203.png)


### Deployment Note
No server side settings update required.