### PR TITLE
[HotFix] Add New Institution: Ferris State University [CAS-71]

### DIFF
--- a/cas-server-webapp/src/main/webapp/WEB-INF/spring-configuration/authenticationDelegation.xml
+++ b/cas-server-webapp/src/main/webapp/WEB-INF/spring-configuration/authenticationDelegation.xml
@@ -42,6 +42,12 @@ under the License.
         <property name="name" value="${cas.okstate.client.name}" />
         <property name="casProtocol" value="${cas.okstate.cas.protocol}" />
     </bean>
+    <!-- Ferris State University -->
+    <bean id="ferris" class="org.pac4j.cas.client.CasClient">
+        <property name="casLoginUrl" value="${cas.ferris.login.url}" />
+        <property name="name" value="${cas.ferris.client.name}" />
+        <property name="casProtocol" value="${cas.ferris.cas.protocol}" />
+    </bean>
 
     <!-- General Configuration for All Clients -->
     <bean id="clients" class="org.pac4j.core.client.Clients">
@@ -50,6 +56,7 @@ under the License.
             <list>
                 <ref bean="orcid" />
                 <ref bean="okstate" />
+                <ref bean="ferris" />
             </list>
         </property>
     </bean>

--- a/cas-server-webapp/src/main/webapp/WEB-INF/view/jsp/default/ui/casInstitutionLoginView.jsp
+++ b/cas-server-webapp/src/main/webapp/WEB-INF/view/jsp/default/ui/casInstitutionLoginView.jsp
@@ -52,6 +52,8 @@
                 return;
             } else if (login_url == "okstate") {
                 login_url = "${okstateUrl}";
+            } else if (login_url == "ferris") {
+                login_url = "${ferrisUrl}";
             }
             window.location = login_url;
         }

--- a/etc/cas.properties
+++ b/etc/cas.properties
@@ -51,6 +51,11 @@ cas.okstate.login.url=https://stgcas.okstate.edu/cas/login
 cas.okstate.client.name=okstate
 cas.okstate.cas.protocol=SAML
 #
+# CAS: Ferris State University
+cas.ferris.login.url=https://lpcas.ferris.edu/cas-web/login
+cas.ferris.client.name=ferris
+cas.ferris.cas.protocol=CAS20
+#
 # OAuth: ORCID
 oauth.orcid.authorize.url=https://orcid.org/oauth/authorize
 oauth.orcid.token.url=https://pub.orcid.org/oauth/token


### PR DESCRIPTION
## Purpose

Add Ferris State University to OSF Institutions.

## Deployment Notes

- [x] Add the following to the `institution-auth.xsl` to the same section where OKState is.
```
<!-- Ferris State University (FERRIS) -->
<xsl:when test="$idp='ferris'">
    <id>ferris</id>
    <user>
        <username><xsl:value-of select="//attribute[@name='EmailAddress']/@value"/></username>
        <fullname><xsl:value-of select="//attribute[@name='Formatted Name']/@value"/></fullname>
        <familyName/>
        <givenName/>
        <middleNames/>
        <suffix/>
    </user>
</xsl:when>
```

## Tickets and PRs

Ticket: https://openscience.atlassian.net/browse/CAS-71
OSF PR: https://github.com/CenterForOpenScience/osf.io/pull/7608