### PR TITLE
[HotFix] Delegation and OAuth URL [No Ticket]

### DIFF
--- a/etc/cas.properties
+++ b/etc/cas.properties
@@ -41,7 +41,7 @@ cas.institution.login.url=/login?campaign=institution
 ##
 # Authentication Delegation: General
 #
-delegation.redirect.uri=${server.name}login
+delegation.redirect.uri=${server.name}/login
 
 ##
 # Authentication Delegation: Clients
@@ -86,7 +86,7 @@ osf.database.hibernate.dialect=org.hibernate.dialect.PostgreSQL82Dialect
 #
 # OAuth Access Token session length in seconds
 oauth.accessTokenDuration=3600
-oauth.loginUrl=${server.name}login
+oauth.loginUrl=${server.name}/login
 
 
 #### Central Authentication Service ####


### PR DESCRIPTION
Add missing slash `\` after `${server.name}` for `delegation.redirect.uri` and `oauth.loginUrl`.