### PR TITLE
[HotFix] Fix Preprints Provider Domains [No Ticket]

### DIFF
--- a/etc/services/preprints-agrixiv.json
+++ b/etc/services/preprints-agrixiv.json
@@ -3,7 +3,7 @@
   "id" : 203948234207244,
   "name" : "AgriXiv",
   "description" : "",
-  "serviceId" : "^https?://(localhost|127\\.0\\.0\\.1):5000/(login|logout)/?\\?next=https?(%3A|:)(%2F|/)(%2F|/)((local\\.agrixiv\\.(org|com)(%3A|:)4200)|((localhost|127\\.0\\.0\\.1)(%3A|:)5000(%2F|/)preprints(%2F|/)agrixiv))($|%2F|/).*",
+  "serviceId" : "^https?://(localhost|127\\.0\\.0\\.1):5000/(login|logout)/?\\?next=https?(%3A|:)(%2F|/)(%2F|/)((local\\.agrixiv\\.org(%3A|:)4200)|((localhost|127\\.0\\.0\\.1)(%3A|:)5000(%2F|/)preprints(%2F|/)agrixiv))($|%2F|/).*",
   "evaluationOrder" : "1000",
   "logo": "http://localhost:8080/images/preprints-agrixiv-logo.png",
   "attributeReleasePolicy" : {

--- a/etc/services/preprints-bitss.json
+++ b/etc/services/preprints-bitss.json
@@ -3,7 +3,7 @@
   "id" : 203948234207245,
   "name" : "BITSS",
   "description" : "",
-  "serviceId" : "^https?://(localhost|127\\.0\\.0\\.1):5000/(login|logout)/?\\?next=https?(%3A|:)(%2F|/)(%2F|/)((local\\.bitss\\.(org|com)(%3A|:)4200)|((localhost|127\\.0\\.0\\.1)(%3A|:)5000(%2F|/)preprints(%2F|/)bitss))($|%2F|/).*",
+  "serviceId" : "^https?://(localhost|127\\.0\\.0\\.1):5000/(login|logout)/?\\?next=https?(%3A|:)(%2F|/)(%2F|/)((local\\.bitss\\.org(%3A|:)4200)|((localhost|127\\.0\\.0\\.1)(%3A|:)5000(%2F|/)preprints(%2F|/)bitss))($|%2F|/).*",
   "evaluationOrder" : "1000",
   "logo": "http://localhost:8080/images/preprints-bitss-logo.png",
   "attributeReleasePolicy" : {

--- a/etc/services/preprints-engrxiv.json
+++ b/etc/services/preprints-engrxiv.json
@@ -3,7 +3,7 @@
   "id" : 203948234207242,
   "name" : "engrXiv",
   "description" : "",
-  "serviceId" : "^https?://(localhost|127\\.0\\.0\\.1):5000/(login|logout)/?\\?next=https?(%3A|:)(%2F|/)(%2F|/)((local\\.engrxiv\\.(org|com)(%3A|:)4200)|((localhost|127\\.0\\.0\\.1)(%3A|:)5000(%2F|/)preprints(%2F|/)engrxiv))($|%2F|/).*",
+  "serviceId" : "^https?://(localhost|127\\.0\\.0\\.1):5000/(login|logout)/?\\?next=https?(%3A|:)(%2F|/)(%2F|/)((local\\.engrxiv\\.org(%3A|:)4200)|((localhost|127\\.0\\.0\\.1)(%3A|:)5000(%2F|/)preprints(%2F|/)engrxiv))($|%2F|/).*",
   "evaluationOrder" : "1000",
   "logo" : "http://localhost:8080/images/preprints-engrxiv-logo.png",
   "attributeReleasePolicy" : {

--- a/etc/services/preprints-experimentalprotocols.json
+++ b/etc/services/preprints-experimentalprotocols.json
@@ -3,7 +3,7 @@
   "id" : 203948234207258,
   "name" : "Experimental Protocols",
   "description" : "",
-  "serviceId" : "^https?://(localhost|127\\.0\\.0\\.1):5000/(login|logout)/?\\?next=https?(%3A|:)(%2F|/)(%2F|/)((local\\.experimentalprotocols\\.(org|com)(%3A|:)4200)|((localhost|127\\.0\\.0\\.1)(%3A|:)5000(%2F|/)preprints(%2F|/)experimentalprotocols))($|%2F|/).*",
+  "serviceId" : "^https?://(localhost|127\\.0\\.0\\.1):5000/(login|logout)/?\\?next=https?(%3A|:)(%2F|/)(%2F|/)((local\\.experimentalprotocols\\.org(%3A|:)4200)|((localhost|127\\.0\\.0\\.1)(%3A|:)5000(%2F|/)preprints(%2F|/)experimentalprotocols))($|%2F|/).*",
   "evaluationOrder" : "1000",
   "logo": "http://localhost:8080/images/preprints-experimentalprotocols-logo.png",
   "attributeReleasePolicy" : {

--- a/etc/services/preprints-lawarxiv.json
+++ b/etc/services/preprints-lawarxiv.json
@@ -3,7 +3,7 @@
   "id" : 203948234207247,
   "name" : "LawArXiv",
   "description" : "",
-  "serviceId" : "^https?://(localhost|127\\.0\\.0\\.1):5000/(login|logout)/?\\?next=https?(%3A|:)(%2F|/)(%2F|/)((local\\.lawarxiv\\.(org|com)(%3A|:)4200)|((localhost|127\\.0\\.0\\.1)(%3A|:)5000(%2F|/)preprints(%2F|/)lawarxiv))($|%2F|/).*",
+  "serviceId" : "^https?://(localhost|127\\.0\\.0\\.1):5000/(login|logout)/?\\?next=https?(%3A|:)(%2F|/)(%2F|/)((local\\.lawarxiv\\.info(%3A|:)4200)|((localhost|127\\.0\\.0\\.1)(%3A|:)5000(%2F|/)preprints(%2F|/)lawarxiv))($|%2F|/).*",
   "evaluationOrder" : "1000",
   "logo" : "http://localhost:8080/images/preprints-lawarxiv-logo.png",
   "attributeReleasePolicy" : {

--- a/etc/services/preprints-lissa.json
+++ b/etc/services/preprints-lissa.json
@@ -3,7 +3,7 @@
   "id" : 203948234207249,
   "name" : "LISSA",
   "description" : "",
-  "serviceId" : "^https?://(localhost|127\\.0\\.0\\.1):5000/(login|logout)/?\\?next=https?(%3A|:)(%2F|/)(%2F|/)((local\\.lissa\\.(org|com)(%3A|:)4200)|((localhost|127\\.0\\.0\\.1)(%3A|:)5000(%2F|/)preprints(%2F|/)lissa))($|%2F|/).*",
+  "serviceId" : "^https?://(localhost|127\\.0\\.0\\.1):5000/(login|logout)/?\\?next=https?(%3A|:)(%2F|/)(%2F|/)((local\\.lissarchive\\.org(%3A|:)4200)|((localhost|127\\.0\\.0\\.1)(%3A|:)5000(%2F|/)preprints(%2F|/)lissa))($|%2F|/).*",
   "evaluationOrder" : "1000",
   "logo": "http://localhost:8080/images/preprints-lissa-logo.png",
   "attributeReleasePolicy" : {

--- a/etc/services/preprints-mindrxiv.json
+++ b/etc/services/preprints-mindrxiv.json
@@ -3,7 +3,7 @@
   "id" : 203948234207250,
   "name" : "MindRxiv",
   "description" : "",
-  "serviceId" : "^https?://(localhost|127\\.0\\.0\\.1):5000/(login|logout)/?\\?next=https?(%3A|:)(%2F|/)(%2F|/)((local\\.mindrxiv\\.(org|com)(%3A|:)4200)|((localhost|127\\.0\\.0\\.1)(%3A|:)5000(%2F|/)preprints(%2F|/)mindrxiv))($|%2F|/).*",
+  "serviceId" : "^https?://(localhost|127\\.0\\.0\\.1):5000/(login|logout)/?\\?next=https?(%3A|:)(%2F|/)(%2F|/)((local\\.mindrxiv\\.org(%3A|:)4200)|((localhost|127\\.0\\.0\\.1)(%3A|:)5000(%2F|/)preprints(%2F|/)mindrxiv))($|%2F|/).*",
   "evaluationOrder" : "1000",
   "logo": "http://localhost:8080/images/preprints-mindrxiv-logo.png",
   "attributeReleasePolicy" : {

--- a/etc/services/preprints-psyarxiv.json
+++ b/etc/services/preprints-psyarxiv.json
@@ -3,7 +3,7 @@
   "id" : 203948234207243,
   "name" : "PsyArXiv",
   "description" : "",
-  "serviceId" : "^https?://(localhost|127\\.0\\.0\\.1):5000/(login|logout)/?\\?next=https?(%3A|:)(%2F|/)(%2F|/)((local\\.psyarxiv\\.(org|com)(%3A|:)4200)|((localhost|127\\.0\\.0\\.1)(%3A|:)5000(%2F|/)preprints(%2F|/)psyarxiv))($|%2F|/).*",
+  "serviceId" : "^https?://(localhost|127\\.0\\.0\\.1):5000/(login|logout)/?\\?next=https?(%3A|:)(%2F|/)(%2F|/)((local\\.psyarxiv\\.com(%3A|:)4200)|((localhost|127\\.0\\.0\\.1)(%3A|:)5000(%2F|/)preprints(%2F|/)psyarxiv))($|%2F|/).*",
   "evaluationOrder" : "1000",
   "logo" : "http://localhost:8080/images/preprints-psyarxiv-logo.png",
   "attributeReleasePolicy" : {

--- a/etc/services/preprints-scielo.json
+++ b/etc/services/preprints-scielo.json
@@ -3,7 +3,7 @@
   "id" : 203948234207246,
   "name" : "SciELO",
   "description" : "",
-  "serviceId" : "^https?://(localhost|127\\.0\\.0\\.1):5000/(login|logout)/?\\?next=https?(%3A|:)(%2F|/)(%2F|/)((local\\.scielo\\.(org|com)(%3A|:)4200)|((localhost|127\\.0\\.0\\.1)(%3A|:)5000(%2F|/)preprints(%2F|/)scielo))($|%2F|/).*",
+  "serviceId" : "^https?://(localhost|127\\.0\\.0\\.1):5000/(login|logout)/?\\?next=https?(%3A|:)(%2F|/)(%2F|/)((local\\.scielo\\.org(%3A|:)4200)|((localhost|127\\.0\\.0\\.1)(%3A|:)5000(%2F|/)preprints(%2F|/)scielo))($|%2F|/).*",
   "evaluationOrder" : "1000",
   "logo": "http://localhost:8080/images/preprints-scielo-logo.png",
   "attributeReleasePolicy" : {

--- a/etc/services/preprints-socarxiv.json
+++ b/etc/services/preprints-socarxiv.json
@@ -3,7 +3,7 @@
   "id" : 203948234207241,
   "name" : "SocArXiv",
   "description" : "",
-  "serviceId" : "^https?://(localhost|127\\.0\\.0\\.1):5000/(login|logout)/?\\?next=https?(%3A|:)(%2F|/)(%2F|/)((local\\.socarxiv\\.(org|com)(%3A|:)4200)|((localhost|127\\.0\\.0\\.1)(%3A|:)5000(%2F|/)preprints(%2F|/)socarxiv))($|%2F|/).*",
+  "serviceId" : "^https?://(localhost|127\\.0\\.0\\.1):5000/(login|logout)/?\\?next=https?(%3A|:)(%2F|/)(%2F|/)((local\\.socarxiv\\.org(%3A|:)4200)|((localhost|127\\.0\\.0\\.1)(%3A|:)5000(%2F|/)preprints(%2F|/)socarxiv))($|%2F|/).*",
   "evaluationOrder" : "1000",
   "logo" : "http://localhost:8080/images/preprints-socarxiv-logo.png",
   "attributeReleasePolicy" : {

--- a/etc/services/preprints-sportrxiv.json
+++ b/etc/services/preprints-sportrxiv.json
@@ -3,7 +3,7 @@
   "id" : 203948234207252,
   "name" : "SportRxiv",
   "description" : "",
-  "serviceId" : "^https?://(localhost|127\\.0\\.0\\.1):5000/(login|logout)/?\\?next=https?(%3A|:)(%2F|/)(%2F|/)((local\\.sportrxiv\\.(org|com)(%3A|:)4200)|((localhost|127\\.0\\.0\\.1)(%3A|:)5000(%2F|/)preprints(%2F|/)sportrxiv))($|%2F|/).*",
+  "serviceId" : "^https?://(localhost|127\\.0\\.0\\.1):5000/(login|logout)/?\\?next=https?(%3A|:)(%2F|/)(%2F|/)((local\\.sportrxiv\\.org(%3A|:)4200)|((localhost|127\\.0\\.0\\.1)(%3A|:)5000(%2F|/)preprints(%2F|/)sportrxiv))($|%2F|/).*",
   "evaluationOrder" : "1000",
   "logo": "http://localhost:8080/images/preprints-sportrxiv-logo.png",
   "attributeReleasePolicy" : {

--- a/etc/services/preprints-thesiscommons.json
+++ b/etc/services/preprints-thesiscommons.json
@@ -3,7 +3,7 @@
   "id" : 203948234207253,
   "name" : "Thesis Commons",
   "description" : "",
-  "serviceId" : "^https?://(localhost|127\\.0\\.0\\.1):5000/(login|logout)/?\\?next=https?(%3A|:)(%2F|/)(%2F|/)((local\\.thesiscommons\\.(org|com)(%3A|:)4200)|((localhost|127\\.0\\.0\\.1)(%3A|:)5000(%2F|/)preprints(%2F|/)thesiscommons))($|%2F|/).*",
+  "serviceId" : "^https?://(localhost|127\\.0\\.0\\.1):5000/(login|logout)/?\\?next=https?(%3A|:)(%2F|/)(%2F|/)((local\\.thesiscommons\\.org(%3A|:)4200)|((localhost|127\\.0\\.0\\.1)(%3A|:)5000(%2F|/)preprints(%2F|/)thesiscommons))($|%2F|/).*",
   "evaluationOrder" : "1000",
   "logo": "http://localhost:8080/images/preprints-thesiscommons-logo.png",
   "attributeReleasePolicy" : {


### PR DESCRIPTION
Use correct domain instead of `(org|com)` for eligible preprints providers.