### PR TITLE
[HotFix] Update the Name for Preprints Providers [CAS-105] [CAS-106]

### DIFF
--- a/cas-server-webapp/src/main/webapp/WEB-INF/view/jsp/default/ui/casLoginView.jsp
+++ b/cas-server-webapp/src/main/webapp/WEB-INF/view/jsp/default/ui/casLoginView.jsp
@@ -43,7 +43,7 @@
                     <c:if test="${not empty registeredService.logo && not empty registeredService.name}">
                         <td><img id="service-logo" src="${registeredService.logo}"> </td>
                         <td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
-                        <td><span class="service-name">${registeredService.name} Preprints</span></td>
+                        <td><span class="service-name">${registeredService.name}</span></td>
                     </c:if>
                 </tr>
             </table>

--- a/cas-server-webapp/src/main/webapp/WEB-INF/view/jsp/default/ui/casOtpLoginView.jsp
+++ b/cas-server-webapp/src/main/webapp/WEB-INF/view/jsp/default/ui/casOtpLoginView.jsp
@@ -42,7 +42,7 @@
                     <c:if test="${not empty registeredService.logo && not empty registeredService.name}">
                         <td><img id="service-logo" class="service-logo-${registeredService.name}" src="${registeredService.logo}"> </td>
                         <td>&nbsp;&nbsp;&nbsp;</td>
-                        <td><span class="service-name">${registeredService.name} Preprints</span></td>
+                        <td><span class="service-name">${registeredService.name}</span></td>
                     </c:if>
                 </tr>
             </table>

--- a/etc/services/preprints-agrixiv.json
+++ b/etc/services/preprints-agrixiv.json
@@ -1,7 +1,7 @@
 {
   "@class" : "org.jasig.cas.services.RegexRegisteredService",
   "id" : 203948234207244,
-  "name" : "AgriXiv",
+  "name" : "AgriXiv Preprints",
   "description" : "",
   "serviceId" : "^https?://(localhost|127\\.0\\.0\\.1):5000/(login|logout)/?\\?next=https?(%3A|:)(%2F|/)(%2F|/)((local\\.agrixiv\\.org(%3A|:)4200)|((localhost|127\\.0\\.0\\.1)(%3A|:)5000(%2F|/)preprints(%2F|/)agrixiv))($|%2F|/).*",
   "evaluationOrder" : "1000",

--- a/etc/services/preprints-bitss.json
+++ b/etc/services/preprints-bitss.json
@@ -1,7 +1,7 @@
 {
   "@class" : "org.jasig.cas.services.RegexRegisteredService",
   "id" : 203948234207245,
-  "name" : "BITSS",
+  "name" : "BITSS Preprints",
   "description" : "",
   "serviceId" : "^https?://(localhost|127\\.0\\.0\\.1):5000/(login|logout)/?\\?next=https?(%3A|:)(%2F|/)(%2F|/)((local\\.bitss\\.org(%3A|:)4200)|((localhost|127\\.0\\.0\\.1)(%3A|:)5000(%2F|/)preprints(%2F|/)bitss))($|%2F|/).*",
   "evaluationOrder" : "1000",

--- a/etc/services/preprints-engrxiv.json
+++ b/etc/services/preprints-engrxiv.json
@@ -1,7 +1,7 @@
 {
   "@class" : "org.jasig.cas.services.RegexRegisteredService",
   "id" : 203948234207242,
-  "name" : "engrXiv",
+  "name" : "engrXiv Preprints",
   "description" : "",
   "serviceId" : "^https?://(localhost|127\\.0\\.0\\.1):5000/(login|logout)/?\\?next=https?(%3A|:)(%2F|/)(%2F|/)((local\\.engrxiv\\.org(%3A|:)4200)|((localhost|127\\.0\\.0\\.1)(%3A|:)5000(%2F|/)preprints(%2F|/)engrxiv))($|%2F|/).*",
   "evaluationOrder" : "1000",

--- a/etc/services/preprints-experimentalprotocols.json
+++ b/etc/services/preprints-experimentalprotocols.json
@@ -1,7 +1,7 @@
 {
   "@class" : "org.jasig.cas.services.RegexRegisteredService",
   "id" : 203948234207258,
-  "name" : "Experimental Protocols",
+  "name" : "Experimental Protocols Preprints",
   "description" : "",
   "serviceId" : "^https?://(localhost|127\\.0\\.0\\.1):5000/(login|logout)/?\\?next=https?(%3A|:)(%2F|/)(%2F|/)((local\\.experimentalprotocols\\.org(%3A|:)4200)|((localhost|127\\.0\\.0\\.1)(%3A|:)5000(%2F|/)preprints(%2F|/)experimentalprotocols))($|%2F|/).*",
   "evaluationOrder" : "1000",

--- a/etc/services/preprints-focusarchive.json
+++ b/etc/services/preprints-focusarchive.json
@@ -1,7 +1,7 @@
 {
   "@class" : "org.jasig.cas.services.RegexRegisteredService",
   "id" : 203948234207248,
-  "name" : "FocUS Archive",
+  "name" : "FocUS Archive Preprints",
   "description" : "",
   "serviceId" : "^https?://(localhost|127\\.0\\.0\\.1):5000/(login|logout)/?\\?next=https?(%3A|:)(%2F|/)(%2F|/)((local\\.focusarchive\\.(org|com)(%3A|:)4200)|((localhost|127\\.0\\.0\\.1)(%3A|:)5000(%2F|/)preprints(%2F|/)focusarchive))($|%2F|/).*",
   "evaluationOrder" : "1000",

--- a/etc/services/preprints-inarxiv.json
+++ b/etc/services/preprints-inarxiv.json
@@ -1,7 +1,7 @@
 {
   "@class" : "org.jasig.cas.services.RegexRegisteredService",
   "id" : 203948234207257,
-  "name" : "INA-Rxiv",
+  "name" : "INA-Rxiv Preprints",
   "description" : "",
   "serviceId" : "^https?://(localhost|127\\.0\\.0\\.1):5000/(login|logout)/?\\?next=https?(%3A|:)(%2F|/)(%2F|/)((local\\.inarxiv\\.(org|com)(%3A|:)4200)|((localhost|127\\.0\\.0\\.1)(%3A|:)5000(%2F|/)preprints(%2F|/)inarxiv))($|%2F|/).*",
   "evaluationOrder" : "1000",

--- a/etc/services/preprints-lawarxiv.json
+++ b/etc/services/preprints-lawarxiv.json
@@ -1,7 +1,7 @@
 {
   "@class" : "org.jasig.cas.services.RegexRegisteredService",
   "id" : 203948234207247,
-  "name" : "LawArXiv",
+  "name" : "LawArXiv Preprints",
   "description" : "",
   "serviceId" : "^https?://(localhost|127\\.0\\.0\\.1):5000/(login|logout)/?\\?next=https?(%3A|:)(%2F|/)(%2F|/)((local\\.lawarxiv\\.info(%3A|:)4200)|((localhost|127\\.0\\.0\\.1)(%3A|:)5000(%2F|/)preprints(%2F|/)lawarxiv))($|%2F|/).*",
   "evaluationOrder" : "1000",

--- a/etc/services/preprints-lissa.json
+++ b/etc/services/preprints-lissa.json
@@ -1,7 +1,7 @@
 {
   "@class" : "org.jasig.cas.services.RegexRegisteredService",
   "id" : 203948234207249,
-  "name" : "LISSA",
+  "name" : "LIS Scholarship Archive Preprints",
   "description" : "",
   "serviceId" : "^https?://(localhost|127\\.0\\.0\\.1):5000/(login|logout)/?\\?next=https?(%3A|:)(%2F|/)(%2F|/)((local\\.lissarchive\\.org(%3A|:)4200)|((localhost|127\\.0\\.0\\.1)(%3A|:)5000(%2F|/)preprints(%2F|/)lissa))($|%2F|/).*",
   "evaluationOrder" : "1000",

--- a/etc/services/preprints-medarxiv.json
+++ b/etc/services/preprints-medarxiv.json
@@ -1,7 +1,7 @@
 {
   "@class" : "org.jasig.cas.services.RegexRegisteredService",
   "id" : 203948234207256,
-  "name" : "MedArXiv",
+  "name" : "MedArXiv Preprints",
   "description" : "",
   "serviceId" : "^https?://(localhost|127\\.0\\.0\\.1):5000/(login|logout)/?\\?next=https?(%3A|:)(%2F|/)(%2F|/)((local\\.medarxiv\\.(org|com)(%3A|:)4200)|((localhost|127\\.0\\.0\\.1)(%3A|:)5000(%2F|/)preprints(%2F|/)medarxiv))($|%2F|/).*",
   "evaluationOrder" : "1000",

--- a/etc/services/preprints-mindrxiv.json
+++ b/etc/services/preprints-mindrxiv.json
@@ -1,7 +1,7 @@
 {
   "@class" : "org.jasig.cas.services.RegexRegisteredService",
   "id" : 203948234207250,
-  "name" : "MindRxiv",
+  "name" : "MindRxiv Preprints",
   "description" : "",
   "serviceId" : "^https?://(localhost|127\\.0\\.0\\.1):5000/(login|logout)/?\\?next=https?(%3A|:)(%2F|/)(%2F|/)((local\\.mindrxiv\\.org(%3A|:)4200)|((localhost|127\\.0\\.0\\.1)(%3A|:)5000(%2F|/)preprints(%2F|/)mindrxiv))($|%2F|/).*",
   "evaluationOrder" : "1000",

--- a/etc/services/preprints-nutrixiv.json
+++ b/etc/services/preprints-nutrixiv.json
@@ -1,7 +1,7 @@
 {
   "@class" : "org.jasig.cas.services.RegexRegisteredService",
   "id" : 203948234207255,
-  "name" : "NutriXiv",
+  "name" : "NutriXiv Preprints",
   "description" : "",
   "serviceId" : "^https?://(localhost|127\\.0\\.0\\.1):5000/(login|logout)/?\\?next=https?(%3A|:)(%2F|/)(%2F|/)((local\\.nutrixiv\\.(org|com)(%3A|:)4200)|((localhost|127\\.0\\.0\\.1)(%3A|:)5000(%2F|/)preprints(%2F|/)nutrixiv))($|%2F|/).*",
   "evaluationOrder" : "1000",

--- a/etc/services/preprints-paleorxiv.json
+++ b/etc/services/preprints-paleorxiv.json
@@ -1,7 +1,7 @@
 {
   "@class" : "org.jasig.cas.services.RegexRegisteredService",
   "id" : 203948234207251,
-  "name" : "PaleorXiv",
+  "name" : "PaleorXiv Preprints",
   "description" : "",
   "serviceId" : "^https?://(localhost|127\\.0\\.0\\.1):5000/(login|logout)/?\\?next=https?(%3A|:)(%2F|/)(%2F|/)((local\\.paleorxiv\\.(org|com)(%3A|:)4200)|((localhost|127\\.0\\.0\\.1)(%3A|:)5000(%2F|/)preprints(%2F|/)paleorxiv))($|%2F|/).*",
   "evaluationOrder" : "1000",

--- a/etc/services/preprints-psyarxiv.json
+++ b/etc/services/preprints-psyarxiv.json
@@ -1,7 +1,7 @@
 {
   "@class" : "org.jasig.cas.services.RegexRegisteredService",
   "id" : 203948234207243,
-  "name" : "PsyArXiv",
+  "name" : "PsyArXiv Preprints",
   "description" : "",
   "serviceId" : "^https?://(localhost|127\\.0\\.0\\.1):5000/(login|logout)/?\\?next=https?(%3A|:)(%2F|/)(%2F|/)((local\\.psyarxiv\\.com(%3A|:)4200)|((localhost|127\\.0\\.0\\.1)(%3A|:)5000(%2F|/)preprints(%2F|/)psyarxiv))($|%2F|/).*",
   "evaluationOrder" : "1000",

--- a/etc/services/preprints-scielo.json
+++ b/etc/services/preprints-scielo.json
@@ -1,7 +1,7 @@
 {
   "@class" : "org.jasig.cas.services.RegexRegisteredService",
   "id" : 203948234207246,
-  "name" : "SciELO",
+  "name" : "SciELO Preprints",
   "description" : "",
   "serviceId" : "^https?://(localhost|127\\.0\\.0\\.1):5000/(login|logout)/?\\?next=https?(%3A|:)(%2F|/)(%2F|/)((local\\.scielo\\.org(%3A|:)4200)|((localhost|127\\.0\\.0\\.1)(%3A|:)5000(%2F|/)preprints(%2F|/)scielo))($|%2F|/).*",
   "evaluationOrder" : "1000",

--- a/etc/services/preprints-socarxiv.json
+++ b/etc/services/preprints-socarxiv.json
@@ -1,7 +1,7 @@
 {
   "@class" : "org.jasig.cas.services.RegexRegisteredService",
   "id" : 203948234207241,
-  "name" : "SocArXiv",
+  "name" : "SocArXiv Preprints",
   "description" : "",
   "serviceId" : "^https?://(localhost|127\\.0\\.0\\.1):5000/(login|logout)/?\\?next=https?(%3A|:)(%2F|/)(%2F|/)((local\\.socarxiv\\.org(%3A|:)4200)|((localhost|127\\.0\\.0\\.1)(%3A|:)5000(%2F|/)preprints(%2F|/)socarxiv))($|%2F|/).*",
   "evaluationOrder" : "1000",

--- a/etc/services/preprints-sportrxiv.json
+++ b/etc/services/preprints-sportrxiv.json
@@ -1,7 +1,7 @@
 {
   "@class" : "org.jasig.cas.services.RegexRegisteredService",
   "id" : 203948234207252,
-  "name" : "SportRxiv",
+  "name" : "SportRxiv Preprints",
   "description" : "",
   "serviceId" : "^https?://(localhost|127\\.0\\.0\\.1):5000/(login|logout)/?\\?next=https?(%3A|:)(%2F|/)(%2F|/)((local\\.sportrxiv\\.org(%3A|:)4200)|((localhost|127\\.0\\.0\\.1)(%3A|:)5000(%2F|/)preprints(%2F|/)sportrxiv))($|%2F|/).*",
   "evaluationOrder" : "1000",


### PR DESCRIPTION
### Purpose

Remove the word "Preprints" from the Thesis Commons login page ([CAS-105](https://openscience.atlassian.net/browse/CAS-105)) and ASU LiveData login page ([CAS-106](https://openscience.atlassian.net/browse/CAS-106)).

### Deployment Notes

@icereval 
- [x] Update each service

### Changes

* ASU LiveData and Thesis Commons
![asu-login](https://user-images.githubusercontent.com/3750414/29721408-17f63ee2-898b-11e7-8a89-2996237dba28.png)
![thesiscommons-login](https://user-images.githubusercontent.com/3750414/29721409-17fd8652-898b-11e7-9fd5-234598dcb26b.png)

* LIS Scholarship Archive Preprints
![lissa-login](https://user-images.githubusercontent.com/3750414/29721629-fc57234e-898b-11e7-9679-2430125749d2.png)


### Tickets

https://openscience.atlassian.net/browse/CAS-105
https://openscience.atlassian.net/browse/CAS-106

