### PR TITLE
[HotFix] Replace "Preprints" with "Papers" for LawArXiv [SVCS-476]

### DIFF
--- a/etc/services/preprints-lawarxiv.json
+++ b/etc/services/preprints-lawarxiv.json
@@ -1,7 +1,7 @@
 {
   "@class" : "org.jasig.cas.services.RegexRegisteredService",
   "id" : 203948234207247,
-  "name" : "LawArXiv Preprints",
+  "name" : "LawArXiv Papers",
   "description" : "",
   "serviceId" : "^https?://(localhost|127\\.0\\.0\\.1):5000/(login|logout)/?\\?next=https?(%3A|:)(%2F|/)(%2F|/)((local\\.lawarxiv\\.info(%3A|:)4200)|((localhost|127\\.0\\.0\\.1)(%3A|:)5000(%2F|/)preprints(%2F|/)lawarxiv))($|%2F|/).*",
   "evaluationOrder" : "1000",


### PR DESCRIPTION
### Purpose

Replace "Preprints" with "Papers" for LawArXiv

### Deployment Notes

- [x] Update service settings according to the diff.
<img width="987" alt="diff" src="https://user-images.githubusercontent.com/3750414/30555978-4802ac16-9c77-11e7-8b66-aa63191b3594.png">

### Changes

![lawarxiv-login](https://user-images.githubusercontent.com/3750414/30549225-41aa70a2-9c62-11e7-8960-7e552a3cca79.png)

### Tickets

https://openscience.atlassian.net/browse/SVCS-476
https://openscience.atlassian.net/browse/EOSF-850
