### PR TITLE
[SVCS-599] Fix OAuth Client Revoke Failures

### DIFF
--- a/cas-server-support-oauth/src/main/java/org/jasig/cas/support/oauth/CentralOAuthService.java
+++ b/cas-server-support-oauth/src/main/java/org/jasig/cas/support/oauth/CentralOAuthService.java
@@ -31,7 +31,6 @@ import org.jasig.cas.support.oauth.token.InvalidTokenException;
 import org.jasig.cas.support.oauth.token.RefreshToken;
 import org.jasig.cas.support.oauth.token.Token;
 import org.jasig.cas.support.oauth.token.TokenType;
-import org.jasig.cas.support.oauth.token.registry.TokenRegistry;
 import org.jasig.cas.ticket.TicketException;
 import org.jasig.cas.ticket.TicketGrantingTicket;
 
@@ -224,7 +223,18 @@ public interface CentralOAuthService {
     Map<String, Scope> getScopes(Set<String> scopeSet) throws InvalidScopeException;
 
     /**
-     * @return the token registry.
+     * Get a list of all the refresh tokens for a given client of the id specified.
+     *
+     * @param clientId the client id
+     * @return a list of refresh tokens
      */
-    TokenRegistry getTokenRegistry();
+    Collection<RefreshToken> getClientRefreshTokens(String clientId);
+
+    /**
+     * Get a list of all the access tokens for a given client of the id specified.
+     *
+     * @param clientId the client id
+     * @return a list of access tokens
+     */
+    Collection<AccessToken> getClientAccessTokens(String clientId);
 }

--- a/cas-server-support-oauth/src/main/java/org/jasig/cas/support/oauth/CentralOAuthService.java
+++ b/cas-server-support-oauth/src/main/java/org/jasig/cas/support/oauth/CentralOAuthService.java
@@ -124,18 +124,16 @@ public interface CentralOAuthService {
      */
     Boolean revokeToken(Token token);
 
-//    /**
-//     * Revoke all Tokens associated with the specified client id, authorized by the client secret.
-//     *
-//     * Note: This method is deprecated. Please avoid implementing it or using its implementations.
-//     *       The functionality is now performed by the `OAuth20RevokeClientTokensController`.
-//     * TODO: Remove this method and its implementations
-//     *
-//     * @param clientId the client id
-//     * @param clientSecret the client secret
-//     * @return a Boolean status if tokens were successfully revoked.
-//     */
-//    Boolean revokeClientTokens(String clientId, String clientSecret);
+    /**
+     * Revoke all Tokens associated with the specified client id, authorized by the client secret.
+     *
+     * Note: This method is deprecated. Please avoid implementing it or using its implementations.
+     *       The functionality is and should be performed by the controller directly.
+     *
+     * @param clientId the client id
+     * @param clientSecret the client secret
+     */
+     void revokeClientTokens(String clientId, String clientSecret);
 
     /**
      * Revoke all Tokens associated with the access token principal id and the client id specified.

--- a/cas-server-support-oauth/src/main/java/org/jasig/cas/support/oauth/CentralOAuthService.java
+++ b/cas-server-support-oauth/src/main/java/org/jasig/cas/support/oauth/CentralOAuthService.java
@@ -31,6 +31,7 @@ import org.jasig.cas.support.oauth.token.InvalidTokenException;
 import org.jasig.cas.support.oauth.token.RefreshToken;
 import org.jasig.cas.support.oauth.token.Token;
 import org.jasig.cas.support.oauth.token.TokenType;
+import org.jasig.cas.support.oauth.token.registry.TokenRegistry;
 import org.jasig.cas.ticket.TicketException;
 import org.jasig.cas.ticket.TicketGrantingTicket;
 
@@ -42,7 +43,8 @@ import java.util.Set;
  * Central OAuth Service.
  *
  * @author Michael Haselton
- * @since 4.1.0
+ * @author Longze Chen
+ * @since 4.1.5
  */
 public interface CentralOAuthService {
 
@@ -123,14 +125,18 @@ public interface CentralOAuthService {
      */
     Boolean revokeToken(Token token);
 
-    /**
-     * Revoke all Tokens associated with the specified client id, authorized by the client secret.
-     *
-     * @param clientId the client id
-     * @param clientSecret the client secret
-     * @return a Boolean status if tokens were successfully revoked.
-     */
-    Boolean revokeClientTokens(String clientId, String clientSecret);
+//    /**
+//     * Revoke all Tokens associated with the specified client id, authorized by the client secret.
+//     *
+//     * Note: This method is deprecated. Please avoid implementing it or using its implementations.
+//     *       The functionality is now performed by the `OAuth20RevokeClientTokensController`.
+//     * TODO: Remove this method and its implementations
+//     *
+//     * @param clientId the client id
+//     * @param clientSecret the client secret
+//     * @return a Boolean status if tokens were successfully revoked.
+//     */
+//    Boolean revokeClientTokens(String clientId, String clientSecret);
 
     /**
      * Revoke all Tokens associated with the access token principal id and the client id specified.
@@ -216,4 +222,9 @@ public interface CentralOAuthService {
      * @throws InvalidScopeException the invalid scope exception
      */
     Map<String, Scope> getScopes(Set<String> scopeSet) throws InvalidScopeException;
+
+    /**
+     * @return the token registry.
+     */
+    TokenRegistry getTokenRegistry();
 }

--- a/cas-server-support-oauth/src/main/java/org/jasig/cas/support/oauth/CentralOAuthServiceImpl.java
+++ b/cas-server-support-oauth/src/main/java/org/jasig/cas/support/oauth/CentralOAuthServiceImpl.java
@@ -291,26 +291,33 @@ public final class CentralOAuthServiceImpl implements CentralOAuthService {
         return ticketRegistry.deleteTicket(token.getTicket().getId());
     }
 
-    @Override
-    public Boolean revokeClientTokens(final String clientId, final String clientSecret) {
-
-        final Collection<RefreshToken> refreshTokens = tokenRegistry.getClientTokens(clientId, RefreshToken.class);
-        final Collection<AccessToken> accessTokens = tokenRegistry.getClientTokens(clientId, AccessToken.class);
-
-        Token token;
-        if (!refreshTokens.isEmpty()) {
-            token = refreshTokens.iterator().next();
-            LOGGER.debug("Revoking refresh token : {}", token.getId());
-        } else if (!accessTokens.isEmpty()) {
-            token = accessTokens.iterator().next();
-            LOGGER.info("Revoking access token : {}", token.getId());
-        } else {
-            // all tokens are cleared
-            return Boolean.TRUE;
-        }
-        ticketRegistry.deleteTicket(token.getTicket().getId());
-        return Boolean.FALSE;
-    }
+//    TODO: Deprecated. Please remove.
+//    @Override
+//    public Boolean revokeClientTokens(final String clientId, final String clientSecret) {
+//        final OAuthRegisteredService service = getRegisteredService(clientId);
+//        if (service == null) {
+//            LOGGER.error("OAuth Registered Service could not be found for clientId : {}", clientId);
+//            return Boolean.FALSE;
+//        }
+//        if (!service.getClientSecret().equals(clientSecret)) {
+//            LOGGER.error("Invalid client secret");
+//            return Boolean.FALSE;
+//        }
+//
+//        final Collection<RefreshToken> refreshTokens = tokenRegistry.getClientTokens(clientId, RefreshToken.class);
+//        for (final RefreshToken token : refreshTokens) {
+//            LOGGER.debug("Revoking refresh token : {}", token.getId());
+//            ticketRegistry.deleteTicket(token.getTicket().getId());
+//        }
+//
+//        final Collection<AccessToken> accessTokens = tokenRegistry.getClientTokens(clientId, AccessToken.class);
+//        for (final AccessToken token : accessTokens) {
+//            LOGGER.debug("Revoking access token : {}", token.getId());
+//            ticketRegistry.deleteTicket(token.getTicket().getId());
+//        }
+//
+//        return Boolean.TRUE;
+//    }
 
     @Override
     public Boolean revokeClientPrincipalTokens(final AccessToken accessToken, final String clientId) {
@@ -484,6 +491,9 @@ public final class CentralOAuthServiceImpl implements CentralOAuthService {
 
         return scopeMap;
     }
+
+    @Override
+    public TokenRegistry getTokenRegistry() {
+        return this.tokenRegistry;
+    }
 }
-
-

--- a/cas-server-support-oauth/src/main/java/org/jasig/cas/support/oauth/CentralOAuthServiceImpl.java
+++ b/cas-server-support-oauth/src/main/java/org/jasig/cas/support/oauth/CentralOAuthServiceImpl.java
@@ -493,7 +493,12 @@ public final class CentralOAuthServiceImpl implements CentralOAuthService {
     }
 
     @Override
-    public TokenRegistry getTokenRegistry() {
-        return this.tokenRegistry;
+    public Collection<RefreshToken> getClientRefreshTokens(String clientId) {
+        return tokenRegistry.getClientTokens(clientId, RefreshToken.class);
+    }
+
+    @Override
+    public Collection<AccessToken> getClientAccessTokens(String clientId) {
+        return tokenRegistry.getClientTokens(clientId, AccessToken.class);
     }
 }

--- a/cas-server-support-oauth/src/main/java/org/jasig/cas/support/oauth/CentralOAuthServiceImpl.java
+++ b/cas-server-support-oauth/src/main/java/org/jasig/cas/support/oauth/CentralOAuthServiceImpl.java
@@ -291,33 +291,10 @@ public final class CentralOAuthServiceImpl implements CentralOAuthService {
         return ticketRegistry.deleteTicket(token.getTicket().getId());
     }
 
-//    TODO: Deprecated. Please remove.
-//    @Override
-//    public Boolean revokeClientTokens(final String clientId, final String clientSecret) {
-//        final OAuthRegisteredService service = getRegisteredService(clientId);
-//        if (service == null) {
-//            LOGGER.error("OAuth Registered Service could not be found for clientId : {}", clientId);
-//            return Boolean.FALSE;
-//        }
-//        if (!service.getClientSecret().equals(clientSecret)) {
-//            LOGGER.error("Invalid client secret");
-//            return Boolean.FALSE;
-//        }
-//
-//        final Collection<RefreshToken> refreshTokens = tokenRegistry.getClientTokens(clientId, RefreshToken.class);
-//        for (final RefreshToken token : refreshTokens) {
-//            LOGGER.debug("Revoking refresh token : {}", token.getId());
-//            ticketRegistry.deleteTicket(token.getTicket().getId());
-//        }
-//
-//        final Collection<AccessToken> accessTokens = tokenRegistry.getClientTokens(clientId, AccessToken.class);
-//        for (final AccessToken token : accessTokens) {
-//            LOGGER.debug("Revoking access token : {}", token.getId());
-//            ticketRegistry.deleteTicket(token.getTicket().getId());
-//        }
-//
-//        return Boolean.TRUE;
-//    }
+    @Override
+    public void revokeClientTokens(final String clientId, final String clientSecret) {
+        throw new UnsupportedOperationException("revokeClientTokens are deprecated and should not be used");
+    }
 
     @Override
     public Boolean revokeClientPrincipalTokens(final AccessToken accessToken, final String clientId) {

--- a/cas-server-support-oauth/src/main/java/org/jasig/cas/support/oauth/CentralOAuthServiceImpl.java
+++ b/cas-server-support-oauth/src/main/java/org/jasig/cas/support/oauth/CentralOAuthServiceImpl.java
@@ -71,6 +71,7 @@ import java.util.Set;
  * Central OAuth Service implementation.
  *
  * @author Michael Haselton
+ * @author Longze Chen
  * @since 4.1.5
  */
 public final class CentralOAuthServiceImpl implements CentralOAuthService {

--- a/cas-server-support-oauth/src/main/java/org/jasig/cas/support/oauth/token/AccessTokenImpl.java
+++ b/cas-server-support-oauth/src/main/java/org/jasig/cas/support/oauth/token/AccessTokenImpl.java
@@ -20,6 +20,7 @@ package org.jasig.cas.support.oauth.token;
 
 import org.hibernate.annotations.OnDelete;
 import org.hibernate.annotations.OnDeleteAction;
+
 import org.jasig.cas.authentication.principal.Service;
 import org.jasig.cas.ticket.ServiceTicket;
 import org.jasig.cas.ticket.ServiceTicketImpl;
@@ -27,22 +28,26 @@ import org.jasig.cas.ticket.Ticket;
 import org.jasig.cas.ticket.TicketGrantingTicket;
 import org.jasig.cas.ticket.TicketGrantingTicketImpl;
 
+import javax.persistence.Access;
+import javax.persistence.AccessType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.Lob;
 import javax.persistence.OneToOne;
 import javax.persistence.Table;
-import javax.persistence.Transient;
+
 import java.util.Set;
 
 /**
  * Access Token Implementation class.
  *
  * @author Michael Haselton
- * @since 4.1.0
+ * @author Longze Chen
+ * @since 4.1.5
  */
 @Entity
 @Table(name="ACCESSTOKEN")
+@Access(AccessType.FIELD)
 public final class AccessTokenImpl extends AbstractToken implements AccessToken {
 
     /** Unique Id for serialization. */
@@ -82,9 +87,16 @@ public final class AccessTokenImpl extends AbstractToken implements AccessToken 
      * @param serviceTicket the service ticket
      * @param scopes the granted scopes
      */
-    public AccessTokenImpl(final String id, final TokenType type, final String clientId, final String principalId,
-                           final TicketGrantingTicket ticketGrantingTicket, final Service service,
-                           final ServiceTicket serviceTicket, final Set<String> scopes) {
+    public AccessTokenImpl(
+            final String id,
+            final TokenType type,
+            final String clientId,
+            final String principalId,
+            final TicketGrantingTicket ticketGrantingTicket,
+            final Service service,
+            final ServiceTicket serviceTicket,
+            final Set<String> scopes
+    ) {
         super(id, clientId, principalId, type, scopes);
 
         this.ticketGrantingTicket = ticketGrantingTicket;
@@ -93,12 +105,10 @@ public final class AccessTokenImpl extends AbstractToken implements AccessToken 
     }
 
     @Override
-    @Transient
     public Ticket getTicket() {
         if (getType() == TokenType.OFFLINE) {
             return this.serviceTicket;
         }
-
         return this.ticketGrantingTicket;
     }
 
@@ -107,7 +117,6 @@ public final class AccessTokenImpl extends AbstractToken implements AccessToken 
         if (getType() == TokenType.OFFLINE) {
             return this.serviceTicket.getGrantingTicket();
         }
-
         return this.ticketGrantingTicket;
     }
 

--- a/cas-server-support-oauth/src/main/java/org/jasig/cas/support/oauth/token/RefreshTokenImpl.java
+++ b/cas-server-support-oauth/src/main/java/org/jasig/cas/support/oauth/token/RefreshTokenImpl.java
@@ -25,6 +25,8 @@ import org.jasig.cas.ticket.Ticket;
 import org.jasig.cas.ticket.TicketGrantingTicket;
 import org.jasig.cas.ticket.TicketGrantingTicketImpl;
 
+import javax.persistence.Access;
+import javax.persistence.AccessType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.OneToOne;
@@ -39,6 +41,7 @@ import java.util.Set;
  */
 @Entity
 @Table(name="REFRESHTOKEN")
+@Access(AccessType.FIELD)
 public final class RefreshTokenImpl extends AbstractToken implements RefreshToken {
 
     /** Unique Id for serialization. */

--- a/cas-server-support-oauth/src/main/java/org/jasig/cas/support/oauth/web/OAuth20RevokeClientTokensController.java
+++ b/cas-server-support-oauth/src/main/java/org/jasig/cas/support/oauth/web/OAuth20RevokeClientTokensController.java
@@ -27,7 +27,6 @@ import org.jasig.cas.support.oauth.OAuthUtils;
 import org.jasig.cas.support.oauth.services.OAuthRegisteredService;
 import org.jasig.cas.support.oauth.token.AccessToken;
 import org.jasig.cas.support.oauth.token.RefreshToken;
-import org.jasig.cas.support.oauth.token.registry.TokenRegistry;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.web.servlet.ModelAndView;
@@ -74,7 +73,7 @@ public final class OAuth20RevokeClientTokensController extends AbstractControlle
             return OAuthUtils.writeJsonError(response, OAuthConstants.INVALID_REQUEST, e.getMessage(), HttpStatus.SC_BAD_REQUEST);
         }
 
-        // Verify that the client service has a valid client_id and client_secret
+        // Verify that the client service has a valid client id and client secret
         final OAuthRegisteredService service = centralOAuthService.getRegisteredService(clientId);
         if (service == null || !service.getClientSecret().equals(clientSecret)) {
             LOGGER.error("Could not revoke client tokens, mismatched client id or client secret");
@@ -86,14 +85,14 @@ public final class OAuth20RevokeClientTokensController extends AbstractControlle
             );
         }
 
-        // Retrieve the tokens from the registry and remove all of them
-        TokenRegistry tokenRegistry = centralOAuthService.getTokenRegistry();
-        final Collection<RefreshToken> refreshTokens = tokenRegistry.getClientTokens(clientId, RefreshToken.class);
+        // Remove all refresh tokens for the client of the specified id
+        final Collection<RefreshToken> refreshTokens = centralOAuthService.getClientRefreshTokens(clientId);
         for (RefreshToken token: refreshTokens) {
             LOGGER.debug("Revoking refresh token : {}", token.getId());
             centralOAuthService.revokeToken(token);
         }
-        final Collection<AccessToken> accessTokens = tokenRegistry.getClientTokens(clientId, AccessToken.class);
+        // Remove all access tokens for the client of the specified id
+        final Collection<AccessToken> accessTokens = centralOAuthService.getClientAccessTokens(clientId);
         for (AccessToken token: accessTokens) {
             LOGGER.info("Revoking access token : {}", token.getId());
             centralOAuthService.revokeToken(token);

--- a/cas-server-support-oauth/src/test/java/org/jasig/cas/support/oauth/web/OAuth20RevokeClientTokensControllerTests.java
+++ b/cas-server-support-oauth/src/test/java/org/jasig/cas/support/oauth/web/OAuth20RevokeClientTokensControllerTests.java
@@ -25,10 +25,15 @@ import org.jasig.cas.support.oauth.CentralOAuthService;
 import org.jasig.cas.support.oauth.OAuthConstants;
 
 import org.jasig.cas.support.oauth.services.OAuthRegisteredService;
+import org.jasig.cas.support.oauth.token.AccessToken;
+import org.jasig.cas.support.oauth.token.RefreshToken;
 import org.junit.Test;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.web.servlet.ModelAndView;
+
+import java.util.Collection;
+import java.util.LinkedList;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
@@ -39,7 +44,8 @@ import static org.mockito.Mockito.when;
  * This class tests the {@link OAuth20RevokeClienTokensController} class.
  *
  * @author Fitz Elliott
- * @since 3.5.2
+ * @author Longze Chen
+ * @since 4.1.5
  */
 public final class OAuth20RevokeClientTokensControllerTests {
 
@@ -56,6 +62,7 @@ public final class OAuth20RevokeClientTokensControllerTests {
     private static final String CONTENT_TYPE = "application/json";
 
 
+    /** Test that no client id raises HTTP 400 Bad Request. */
     @Test
     public void verifyNoClientId() throws Exception {
         final CentralOAuthService centralOAuthService = mock(CentralOAuthService.class);
@@ -85,6 +92,7 @@ public final class OAuth20RevokeClientTokensControllerTests {
         assertEquals(expectedObj.get("error_description").asText(), receivedObj.get("error_description").asText());
     }
 
+    /** Test that no client secret raises HTTP 400 Bad Request. */
     @Test
     public void verifyNoClientSecret() throws Exception {
         final CentralOAuthService centralOAuthService = mock(CentralOAuthService.class);
@@ -114,6 +122,7 @@ public final class OAuth20RevokeClientTokensControllerTests {
         assertEquals(expectedObj.get("error_description").asText(), receivedObj.get("error_description").asText());
     }
 
+    /** Test that client id not found raises HTTP 400 Bad Request. */
     @Test
     public void verifyNoSuchClientId() throws Exception {
         final CentralOAuthService centralOAuthService = mock(CentralOAuthService.class);
@@ -143,6 +152,7 @@ public final class OAuth20RevokeClientTokensControllerTests {
         assertEquals(expectedObj.get("error_description").asText(), receivedObj.get("error_description").asText());
     }
 
+    /** Test that wrong client secret raises HTTP 400 Bad Request. */
     @Test
     public void verifyWrongClientSecret() throws Exception {
         final CentralOAuthService centralOAuthService = mock(CentralOAuthService.class);
@@ -172,9 +182,14 @@ public final class OAuth20RevokeClientTokensControllerTests {
         assertEquals(expectedObj.get("error_description").asText(), receivedObj.get("error_description").asText());
     }
 
+    /* Test that valid client id and secret succeeds and returns HTTP 204 No Content. */
     @Test
     public void verifyOK() throws Exception {
         final CentralOAuthService centralOAuthService = mock(CentralOAuthService.class);
+        final Collection<AccessToken> accessTokens = new LinkedList<>();
+        final Collection<RefreshToken> refreshTokens = new LinkedList<>();
+        when(centralOAuthService.getClientAccessTokens(CLIENT_ID)).thenReturn(accessTokens);
+        when(centralOAuthService.getClientRefreshTokens(CLIENT_ID)).thenReturn(refreshTokens);
 
         final OAuthRegisteredService service = new OAuthRegisteredService();
         service.setClientId(CLIENT_ID);
@@ -197,5 +212,4 @@ public final class OAuth20RevokeClientTokensControllerTests {
         assertNull(mockResponse.getContentType());
         assertEquals("null", mockResponse.getContentAsString());
     }
-
 }

--- a/cas-server-support-oauth/src/test/java/org/jasig/cas/support/oauth/web/OAuth20RevokeClientTokensControllerTests.java
+++ b/cas-server-support-oauth/src/test/java/org/jasig/cas/support/oauth/web/OAuth20RevokeClientTokensControllerTests.java
@@ -24,6 +24,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.jasig.cas.support.oauth.CentralOAuthService;
 import org.jasig.cas.support.oauth.OAuthConstants;
 
+import org.jasig.cas.support.oauth.services.OAuthRegisteredService;
 import org.junit.Test;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
@@ -179,6 +180,11 @@ public final class OAuth20RevokeClientTokensControllerTests {
     public void verifyOK() throws Exception {
         final CentralOAuthService centralOAuthService = mock(CentralOAuthService.class);
         when(centralOAuthService.revokeClientTokens(CLIENT_ID, CLIENT_SECRET)).thenReturn(true);
+
+        final OAuthRegisteredService service = new OAuthRegisteredService();
+        service.setClientId(CLIENT_ID);
+        service.setClientSecret(CLIENT_SECRET);
+        when(centralOAuthService.getRegisteredService(CLIENT_ID)).thenReturn(service);
 
         final MockHttpServletRequest mockRequest = new MockHttpServletRequest("POST", CONTEXT
                 + OAuthConstants.REVOKE_URL);

--- a/cas-server-support-oauth/src/test/java/org/jasig/cas/support/oauth/web/OAuth20RevokeClientTokensControllerTests.java
+++ b/cas-server-support-oauth/src/test/java/org/jasig/cas/support/oauth/web/OAuth20RevokeClientTokensControllerTests.java
@@ -59,10 +59,9 @@ public final class OAuth20RevokeClientTokensControllerTests {
     @Test
     public void verifyNoClientId() throws Exception {
         final CentralOAuthService centralOAuthService = mock(CentralOAuthService.class);
-        when(centralOAuthService.revokeClientTokens(CLIENT_ID, CLIENT_SECRET)).thenReturn(true);
 
-        final MockHttpServletRequest mockRequest = new MockHttpServletRequest("POST", CONTEXT
-                + OAuthConstants.REVOKE_URL);
+        final MockHttpServletRequest mockRequest
+                = new MockHttpServletRequest("POST", CONTEXT + OAuthConstants.REVOKE_URL);
         mockRequest.setParameter(OAuthConstants.CLIENT_ID, "");
         mockRequest.setParameter(OAuthConstants.CLIENT_SECRET, CLIENT_SECRET);
         final MockHttpServletResponse mockResponse = new MockHttpServletResponse();
@@ -89,10 +88,9 @@ public final class OAuth20RevokeClientTokensControllerTests {
     @Test
     public void verifyNoClientSecret() throws Exception {
         final CentralOAuthService centralOAuthService = mock(CentralOAuthService.class);
-        when(centralOAuthService.revokeClientTokens(CLIENT_ID, CLIENT_SECRET)).thenReturn(true);
 
-        final MockHttpServletRequest mockRequest = new MockHttpServletRequest("POST", CONTEXT
-                + OAuthConstants.REVOKE_URL);
+        final MockHttpServletRequest mockRequest
+                = new MockHttpServletRequest("POST", CONTEXT + OAuthConstants.REVOKE_URL);
         mockRequest.setParameter(OAuthConstants.CLIENT_ID, CLIENT_ID);
         mockRequest.setParameter(OAuthConstants.CLIENT_SECRET, "");
         final MockHttpServletResponse mockResponse = new MockHttpServletResponse();
@@ -119,10 +117,9 @@ public final class OAuth20RevokeClientTokensControllerTests {
     @Test
     public void verifyNoSuchClientId() throws Exception {
         final CentralOAuthService centralOAuthService = mock(CentralOAuthService.class);
-        when(centralOAuthService.revokeClientTokens(CLIENT_ID, CLIENT_SECRET)).thenReturn(true);
 
-        final MockHttpServletRequest mockRequest = new MockHttpServletRequest("POST", CONTEXT
-                + OAuthConstants.REVOKE_URL);
+        final MockHttpServletRequest mockRequest
+                = new MockHttpServletRequest("POST", CONTEXT + OAuthConstants.REVOKE_URL);
         mockRequest.setParameter(OAuthConstants.CLIENT_ID, NO_SUCH_CLIENT_ID);
         mockRequest.setParameter(OAuthConstants.CLIENT_SECRET, CLIENT_SECRET);
         final MockHttpServletResponse mockResponse = new MockHttpServletResponse();
@@ -149,10 +146,9 @@ public final class OAuth20RevokeClientTokensControllerTests {
     @Test
     public void verifyWrongClientSecret() throws Exception {
         final CentralOAuthService centralOAuthService = mock(CentralOAuthService.class);
-        when(centralOAuthService.revokeClientTokens(CLIENT_ID, CLIENT_SECRET)).thenReturn(false);
 
-        final MockHttpServletRequest mockRequest = new MockHttpServletRequest("POST", CONTEXT
-                + OAuthConstants.REVOKE_URL);
+        final MockHttpServletRequest mockRequest
+                = new MockHttpServletRequest("POST", CONTEXT + OAuthConstants.REVOKE_URL);
         mockRequest.setParameter(OAuthConstants.CLIENT_ID, CLIENT_ID);
         mockRequest.setParameter(OAuthConstants.CLIENT_SECRET, WRONG_CLIENT_SECRET);
         final MockHttpServletResponse mockResponse = new MockHttpServletResponse();
@@ -179,15 +175,14 @@ public final class OAuth20RevokeClientTokensControllerTests {
     @Test
     public void verifyOK() throws Exception {
         final CentralOAuthService centralOAuthService = mock(CentralOAuthService.class);
-        when(centralOAuthService.revokeClientTokens(CLIENT_ID, CLIENT_SECRET)).thenReturn(true);
 
         final OAuthRegisteredService service = new OAuthRegisteredService();
         service.setClientId(CLIENT_ID);
         service.setClientSecret(CLIENT_SECRET);
         when(centralOAuthService.getRegisteredService(CLIENT_ID)).thenReturn(service);
 
-        final MockHttpServletRequest mockRequest = new MockHttpServletRequest("POST", CONTEXT
-                + OAuthConstants.REVOKE_URL);
+        final MockHttpServletRequest mockRequest
+                = new MockHttpServletRequest("POST", CONTEXT + OAuthConstants.REVOKE_URL);
         mockRequest.setParameter(OAuthConstants.CLIENT_ID, CLIENT_ID);
         mockRequest.setParameter(OAuthConstants.CLIENT_SECRET, CLIENT_SECRET);
         final MockHttpServletResponse mockResponse = new MockHttpServletResponse();


### PR DESCRIPTION
### Ticket

[SVCS-599](https://openscience.atlassian.net/browse/SVCS-599)

### Purpose, Changes, Side Effects and More

In short, the issue is fixed by deprecating `revokeClientTokens()` and move its functionality to the controller `OAuth20RevokeClientTokensController`. Please refer to the ticket for detailed information and discussion.

Note: This PR replaces https://github.com/CenterForOpenScience/cas-overlay/pull/91.