### PR TITLE
[OSF Institutions] California Lutheran University [SVCS-662]

### DIFF
--- a/cas-server-webapp/src/main/webapp/WEB-INF/spring-configuration/authenticationDelegation.xml
+++ b/cas-server-webapp/src/main/webapp/WEB-INF/spring-configuration/authenticationDelegation.xml
@@ -42,6 +42,12 @@ under the License.
         <property name="name" value="${cas.okstate.client.name}" />
         <property name="casProtocol" value="${cas.okstate.cas.protocol}" />
     </bean>
+    <!-- California Lutheran University -->
+    <bean id="callutheran" class="org.pac4j.cas.client.CasClient">
+        <property name="casLoginUrl" value="${cas.callutheran.login.url}" />
+        <property name="name" value="${cas.callutheran.client.name}" />
+        <property name="casProtocol" value="${cas.callutheran.cas.protocol}" />
+    </bean>
     <!-- Ferris State University -->
     <bean id="ferris" class="org.pac4j.cas.client.CasClient">
         <property name="casLoginUrl" value="${cas.ferris.login.url}" />
@@ -56,6 +62,7 @@ under the License.
             <list>
                 <ref bean="orcid" />
                 <ref bean="okstate" />
+                <ref bean="callutheran" />
                 <ref bean="ferris" />
             </list>
         </property>

--- a/cas-server-webapp/src/main/webapp/WEB-INF/view/jsp/default/ui/casInstitutionLoginView.jsp
+++ b/cas-server-webapp/src/main/webapp/WEB-INF/view/jsp/default/ui/casInstitutionLoginView.jsp
@@ -59,19 +59,19 @@
     </section>
 
     <script>
-        function institutionLogin() {
-            var form = document.getElementById('institution-form-select');
-            var login_url = form.options[form.selectedIndex].value;
-            if (login_url == null || login_url == "") {
+        function institutionLogin () {
+            var institutionForm = document.getElementById('institution-form-select');
+            var institutionLoginUrl = institutionForm.options[institutionForm.selectedIndex].value;
+            if(institutionLoginUrl == null || institutionLoginUrl === "") {
                 return;
-            } else if (login_url == "okstate") {
-                login_url = "${okstateUrl}";
-            } else if (login_url == "callutheran") {
-                login_url = "${callutheranUrl}";
-            } else if (login_url == "ferris") {
-                login_url = "${ferrisUrl}";
+            } else if (institutionLoginUrl === "callutheran") {
+                institutionLoginUrl = "${callutheranUrl}";
+            } else if (institutionLoginUrl === "ferris") {
+                institutionLoginUrl = "${ferrisUrl}";
+            } else if (institutionLoginUrl === "okstate") {
+                institutionLoginUrl = "${okstateUrl}";
             }
-            window.location = login_url;
+            window.location = institutionLoginUrl;
         }
     </script>
 </div>

--- a/cas-server-webapp/src/main/webapp/WEB-INF/view/jsp/default/ui/casInstitutionLoginView.jsp
+++ b/cas-server-webapp/src/main/webapp/WEB-INF/view/jsp/default/ui/casInstitutionLoginView.jsp
@@ -66,6 +66,8 @@
                 return;
             } else if (login_url == "okstate") {
                 login_url = "${okstateUrl}";
+            } else if (login_url == "callutheran") {
+                login_url = "${callutheranUrl}";
             } else if (login_url == "ferris") {
                 login_url = "${ferrisUrl}";
             }


### PR DESCRIPTION
### Ticket

https://openscience.atlassian.net/browse/SVCS-662

### Purpose

Add institution login support for California Lutheran University with ID `callutheran`.

### Changes

`callutheran` uses CAS with SAML validation, which is exactly the same as`okstate`.

### Deployment Notes

- [x] Waiting for the institution on updating the test account with attributes
- [x] Update `institutions-auth.xsl` 
```xsl
<!-- California Lutheran University -->
<xsl:when test="$idp='callutheran'">
    <id>callutheran</id>
    <user>
        <username><xsl:value-of select="//attribute[@name='email']/@value"/></username>
        <familyName><xsl:value-of select="//attribute[@name='familyName']/@value"/></familyName>
        <givenName><xsl:value-of select="//attribute[@name='givenName']/@value"/></givenName>
        <fullname/>
        <middleNames/>
        <suffix/>
    </user>
</xsl:when>
```
- [x] Update `cas.properties`
```
# CAS: California Lutheran University
cas.callutheran.login.url=https://sso.callutheran.edu/cas/login
cas.callutheran.client.name=callutheran
cas.callutheran.cas.protocol=SAML
```
- [ ] Blocks the OSF counterpart: https://github.com/CenterForOpenScience/osf.io/pull/8227

### QA Notes

No QA

### Side Effects

Update the event handler code on the institution page .
