### PR TITLE
[Fix] Add Missing Settings for Callutheran

### DIFF
--- a/etc/cas.properties
+++ b/etc/cas.properties
@@ -46,6 +46,11 @@ delegation.redirect.uri=${server.name}/login
 ##
 # Authentication Delegation: Clients
 #
+# CAS: California Lutheran University
+cas.callutheran.login.url=https://sso.callutheran.edu/cas/login
+cas.callutheran.client.name=callutheran
+cas.callutheran.cas.protocol=SAML
+#
 # CAS: Oklahoma State University
 cas.okstate.login.url=https://stgcas.okstate.edu/cas/login
 cas.okstate.client.name=okstate


### PR DESCRIPTION
## Purpose

Add missing settings for institution callutheran in `cas.properties`. Only affects local development.
