### PR TITLE
[SVCS-812] Disable Institution Login For Ferris State University

### DIFF
--- a/cas-server-webapp/src/main/webapp/WEB-INF/spring-configuration/authenticationDelegation.xml
+++ b/cas-server-webapp/src/main/webapp/WEB-INF/spring-configuration/authenticationDelegation.xml
@@ -48,12 +48,6 @@ under the License.
         <property name="name" value="${cas.callutheran.client.name}" />
         <property name="casProtocol" value="${cas.callutheran.cas.protocol}" />
     </bean>
-    <!-- Ferris State University -->
-    <bean id="ferris" class="org.pac4j.cas.client.CasClient">
-        <property name="casLoginUrl" value="${cas.ferris.login.url}" />
-        <property name="name" value="${cas.ferris.client.name}" />
-        <property name="casProtocol" value="${cas.ferris.cas.protocol}" />
-    </bean>
 
     <!-- General Configuration for All Clients -->
     <bean id="clients" class="org.pac4j.core.client.Clients">
@@ -63,7 +57,6 @@ under the License.
                 <ref bean="orcid" />
                 <ref bean="okstate" />
                 <ref bean="callutheran" />
-                <ref bean="ferris" />
             </list>
         </property>
     </bean>

--- a/cas-server-webapp/src/main/webapp/WEB-INF/view/jsp/default/ui/casInstitutionLoginView.jsp
+++ b/cas-server-webapp/src/main/webapp/WEB-INF/view/jsp/default/ui/casInstitutionLoginView.jsp
@@ -67,7 +67,8 @@
             } else if (institutionLoginUrl === "callutheran") {
                 institutionLoginUrl = "${callutheranUrl}";
             } else if (institutionLoginUrl === "ferris") {
-                institutionLoginUrl = "${ferrisUrl}";
+                // Disable institution login Ferris State University
+                return;
             } else if (institutionLoginUrl === "okstate") {
                 institutionLoginUrl = "${okstateUrl}";
             }

--- a/etc/cas.properties
+++ b/etc/cas.properties
@@ -56,11 +56,6 @@ cas.okstate.login.url=https://stgcas.okstate.edu/cas/login
 cas.okstate.client.name=okstate
 cas.okstate.cas.protocol=SAML
 #
-# CAS: Ferris State University
-cas.ferris.login.url=https://lpcas.ferris.edu/cas-web/login
-cas.ferris.client.name=ferris
-cas.ferris.cas.protocol=CAS20
-#
 # OAuth: ORCID
 oauth.orcid.authorize.url=https://orcid.org/oauth/authorize
 oauth.orcid.token.url=https://pub.orcid.org/oauth/token


### PR DESCRIPTION
## Ticket

https://openscience.atlassian.net/browse/SVCS-812

## Purpose

Ferris State University have decided to abandon CAS protocol and use SAML2 for institution login. Remove CAS bean configuration and settings. Disable Ferris State University on the institution login page.

## Changes

* Remove bean configuration and cas settings
* Disable login on the institution login page

## Side effects

OSF PR: https://github.com/CenterForOpenScience/osf.io/pull/8363

## QA Notes

No

## Deployment Notes

* Remove the following from `cas.properties` on the server config. Non-blocking requirement.

```
# CAS: Ferris State University	
cas.ferris.login.url=https://lpcas.ferris.edu/cas-web/login	
cas.ferris.client.name=ferris	
cas.ferris.cas.protocol=CAS20
```
