### PR TITLE
[SVCS-813] Fix 500s CAS Unavailable Page by Adding OSF Context

### DIFF
--- a/cas-server-webapp/src/main/resources/messages.properties
+++ b/cas-server-webapp/src/main/resources/messages.properties
@@ -117,7 +117,7 @@ screen.service.empty.error.message=The services registry of CAS is empty and has
 password.expiration.warning=Your password expires in {0} day(s).  Please <a href="{1}">change your password</a> now.
 password.expiration.loginsRemaining=You have {0} login(s) remaining before you <strong>MUST</strong> change your password.
 screen.accountlocked.heading=This account has been locked.
-screen.accountlocked.message=Please contact <a href="mailto:support@osf.io">support@osf.io</a> to regain access.
+screen.accountlocked.message=Please contact <a style="white-space: nowrap" href="mailto:support@osf.io">support@osf.io</a> to regain access.
 screen.expiredpass.heading=Your password has expired.
 screen.expiredpass.message=Please <a href="{0}">change your password</a>.
 screen.mustchangepass.heading=You must change your password.
@@ -125,7 +125,7 @@ screen.mustchangepass.message=Please <a href="{0}">change your password</a>.
 screen.badhours.heading=Your account is forbidden to login at this time.
 screen.badhours.message=Please try again later.
 screen.badworkstation.heading=You cannot login from this workstation.
-screen.badworkstation.message=Please contact <a href="mailto:support@osf.io">support@osf.io</a> to regain access.
+screen.badworkstation.message=Please contact <a style="white-space: nowrap" href="mailto:support@osf.io">support@osf.io</a> to regain access.
 
 # OSF Login Failure Pages
 screen.loginnotallowed.heading=Account not confirmed

--- a/cas-server-webapp/src/main/resources/messages.properties
+++ b/cas-server-webapp/src/main/resources/messages.properties
@@ -37,6 +37,7 @@ screen.welcome.button.login.orcid=Sign in with ORCID
 screen.welcome.button.clear=CLEAR
 
 screen.general.link.createAccount=Create an OSF account
+screen.general.link.signOutandBackToSignIn=Back to sign in
 screen.general.link.signIn=Sign in
 screen.general.link.signOut=Sign out
 screen.general.link.backToOsf=Back to OSF

--- a/cas-server-webapp/src/main/webapp/WEB-INF/view/jsp/default/ui/casAccountDisabledView.jsp
+++ b/cas-server-webapp/src/main/webapp/WEB-INF/view/jsp/default/ui/casAccountDisabledView.jsp
@@ -19,7 +19,7 @@
 
 --%>
 
-<%-- OSF CAS login exception page for: account disabled --%>
+<%-- Login exception page: account disabled --%>
 
 <jsp:directive.include file="includes/top.jsp"/>
 

--- a/cas-server-webapp/src/main/webapp/WEB-INF/view/jsp/default/ui/casGenericSuccessView.jsp
+++ b/cas-server-webapp/src/main/webapp/WEB-INF/view/jsp/default/ui/casGenericSuccessView.jsp
@@ -19,7 +19,7 @@
 
 --%>
 
-<%-- CAS generic page for logged in (no service) --%>
+<%-- Generic no-service successful login page --%>
 
 <jsp:directive.include file="includes/top.jsp"/>
 

--- a/cas-server-webapp/src/main/webapp/WEB-INF/view/jsp/default/ui/casInstitutionLoginView.jsp
+++ b/cas-server-webapp/src/main/webapp/WEB-INF/view/jsp/default/ui/casInstitutionLoginView.jsp
@@ -19,7 +19,7 @@
 
 --%>
 
-<%-- OSF CAS institution login page --%>
+<%-- Institution login page for OSF --%>
 
 <jsp:directive.include file="includes/top.jsp"/>
 

--- a/cas-server-webapp/src/main/webapp/WEB-INF/view/jsp/default/ui/casLoginNotAllowedView.jsp
+++ b/cas-server-webapp/src/main/webapp/WEB-INF/view/jsp/default/ui/casLoginNotAllowedView.jsp
@@ -19,7 +19,7 @@
 
 --%>
 
-<%-- OSF CAS login exception page for: account not confirmed --%>
+<%-- Login exception page: account not confirmed --%>
 
 <jsp:directive.include file="includes/top.jsp"/>
 

--- a/cas-server-webapp/src/main/webapp/WEB-INF/view/jsp/default/ui/casLoginView.jsp
+++ b/cas-server-webapp/src/main/webapp/WEB-INF/view/jsp/default/ui/casLoginView.jsp
@@ -19,7 +19,7 @@
 
 --%>
 
-<%-- OSF CAS default login page --%>
+<%-- Default login page for OSF --%>
 
 <jsp:directive.include file="includes/top.jsp"/>
 

--- a/cas-server-webapp/src/main/webapp/WEB-INF/view/jsp/default/ui/casLogoutView.jsp
+++ b/cas-server-webapp/src/main/webapp/WEB-INF/view/jsp/default/ui/casLogoutView.jsp
@@ -19,7 +19,7 @@
 
 --%>
 
-<%-- CAS generic page for logged out (no service)  --%>
+<%-- Generic no-service successful logout page --%>
 
 <jsp:directive.include file="includes/top.jsp"/>
 

--- a/cas-server-webapp/src/main/webapp/WEB-INF/view/jsp/default/ui/casOtpLoginView.jsp
+++ b/cas-server-webapp/src/main/webapp/WEB-INF/view/jsp/default/ui/casOtpLoginView.jsp
@@ -19,7 +19,7 @@
 
 --%>
 
-<%-- OSF CAS Two-factor authententication page --%>
+<%-- Two-factor authententication page for OSF --%>
 
 <jsp:directive.include file="includes/top.jsp"/>
 

--- a/cas-server-webapp/src/main/webapp/WEB-INF/view/jsp/default/ui/casRemoteUserFailedLoginView.jsp
+++ b/cas-server-webapp/src/main/webapp/WEB-INF/view/jsp/default/ui/casRemoteUserFailedLoginView.jsp
@@ -19,7 +19,7 @@
 
 --%>
 
-<%-- OSF CAS Institution and ORCiD login exception page --%>
+<%-- Institution login exception page --%>
 
 <jsp:directive.include file="includes/top.jsp"/>
 

--- a/cas-server-webapp/src/main/webapp/WEB-INF/view/jsp/default/ui/casShouldNotHappenView.jsp
+++ b/cas-server-webapp/src/main/webapp/WEB-INF/view/jsp/default/ui/casShouldNotHappenView.jsp
@@ -19,12 +19,7 @@
 
 --%>
 
-<%--
-
-    OSF CAS login exception page for unexpected exceptions including:
-    contributor not claimed, account already merged and other invalid status.
-
---%>
+<%-- Login exception page: invalid or unexpected user status --%>
 
 <jsp:directive.include file="includes/top.jsp"/>
 

--- a/cas-server-webapp/src/main/webapp/WEB-INF/view/jsp/default/ui/includes/bottom.jsp
+++ b/cas-server-webapp/src/main/webapp/WEB-INF/view/jsp/default/ui/includes/bottom.jsp
@@ -23,30 +23,45 @@
 
 </div>  <!-- END #content -->
 
+<spring:eval var="serverName" expression="@casProperties.getProperty('server.name')"/>
+<spring:eval var="osfLoginUrl" expression="@casProperties.getProperty('cas.osf.login.url')"/>
+<spring:eval var="casLogoutUrl" expression="@casProperties.getProperty('cas.logout.url')"/>
+<spring:eval var="createAccountUrl" expression="@casProperties.getProperty('osf.createAccount.url')"/>
+<spring:eval var="osfUrl" expression="@casProperties.getProperty('osf.url')"/>
+
 <c:if test="${empty serviceParam}">
     <%-- Try to obtain the service from the login context first. If failed, get it from the request parameters. --%>
-    <c:set var="serviceParam" value="&service=${osfLoginContext.isServiceUrl() ? osfLoginContext.getServiceUrl() : fn:escapeXml(param.service)}"/>
+    <c:set var="serviceUrl" value="${osfLoginContext.isServiceUrl() ? osfLoginContext.getServiceUrl() : fn:escapeXml(param.service)}"/>
+    <c:set var="serviceParam" value="&service=${serviceUrl}"/>
 </c:if>
 
 <div class="bottom-link">
     <br/>
+    <c:if test="${linkSignOutandBackToSignIn}">
+        <c:set var="osfFullLoginUrl" value="${serverName}${osfLoginUrl}" />
+        <c:set var="casFullLogoutUrl" value="${serverName}${casLogoutUrl}" />
+        <c:url value="${osfFullLoginUrl}" var="osfSignInUrlWithService">
+            <c:param name="service" value="${serviceUrl}" />
+        </c:url>
+        <c:url value="${casFullLogoutUrl}" var="osfSignOutUrlWithService">
+            <c:param name="service" value="${osfSignInUrlWithService}" />
+        </c:url>
+        <a id="link-back-to-sign-in" href="${osfSignOutUrlWithService}"><spring:message code="screen.general.link.signOutandBackToSignIn"/></a>
+        <span style="padding: 25px"></span>
+    </c:if>
     <c:if test="${linkSignIn}">
-        <spring:eval var="osfLoginUrl" expression="@casProperties.getProperty('cas.osf.login.url')"/>
         <a id="link-sign-in" href="${osfLoginUrl}${serviceParam}"><spring:message code="screen.general.link.signIn"/></a>
         <span style="padding: 25px"></span>
     </c:if>
     <c:if test="${linkSignOut}">
-        <spring:eval var="casLogoutUrl" expression="@casProperties.getProperty('cas.logout.url')"/>
         <a id="link-sign-out" href="${casLogoutUrl}?${serviceParam}"><spring:message code="screen.general.link.signOut"/></a>
         <span style="padding: 25px"></span>
     </c:if>
     <c:if test="${linkCreateAccount}">
-        <spring:eval var="createAccountUrl" expression="@casProperties.getProperty('osf.createAccount.url')"/>
         <span><a id="link-create-account" href="${createAccountUrl}${registeredService.properties.registerUrl.getValue()}"><spring:message code="screen.general.link.createAccount"/></a></span>
         <span style="padding: 25px"></span>
     </c:if>
     <c:if test="${linkBackToOsf}">
-        <spring:eval var="osfUrl" expression="@casProperties.getProperty('osf.url')"/>
         <span><a id="link-back-to-osf" href="${osfUrl}"><spring:message code="screen.general.link.backToOsf"/></a></span>
     </c:if>
     <br/>

--- a/cas-server-webapp/src/main/webapp/WEB-INF/view/jsp/default/ui/includes/bottom.jsp
+++ b/cas-server-webapp/src/main/webapp/WEB-INF/view/jsp/default/ui/includes/bottom.jsp
@@ -24,8 +24,8 @@
 </div>  <!-- END #content -->
 
 <c:if test="${empty serviceParam}">
-    <%-- Try to get the service from the login context first. If failed, try to get it from the request parameters. --%>
-    <c:set var="serviceParam" value="&service=${osfLoginContext.isServiceUrl() ? osfLoginContext.getServiceUrl() : param.service ? fn:escapeXml(param.service) : ''}"/>
+    <%-- Try to obtain the service from the login context first. If failed, get it from the request parameters. --%>
+    <c:set var="serviceParam" value="&service=${osfLoginContext.isServiceUrl() ? osfLoginContext.getServiceUrl() : fn:escapeXml(param.service)}"/>
 </c:if>
 
 <div class="bottom-link">

--- a/cas-server-webapp/src/main/webapp/WEB-INF/view/jsp/errors.jsp
+++ b/cas-server-webapp/src/main/webapp/WEB-INF/view/jsp/errors.jsp
@@ -1,0 +1,44 @@
+<%--
+
+    Licensed to Apereo under one or more contributor license
+    agreements. See the NOTICE file distributed with this work
+    for additional information regarding copyright ownership.
+    Apereo licenses this file to you under the Apache License,
+    Version 2.0 (the "License"); you may not use this file
+    except in compliance with the License.  You may obtain a
+    copy of the License at the following location:
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+--%>
+
+<%-- CAS unavailable page for 500s server errors --%>
+
+<jsp:directive.include file="default/ui/includes/top.jsp" />
+
+<div id="msg" class="errors">
+    <h2>${pageContext.errorData.statusCode} - <spring:message code="screen.unavailable.heading" /></h2>
+    <p><spring:message code="screen.unavailable.message" /></p>
+</div>
+
+<spring:message code="screen.osf.login.message.error" var="errorDescription"/>
+<script>
+    description = document.getElementById("description");
+    if (description != null) {
+        description.innerHTML = "<br><br>${errorDescription}";
+    }
+</script>
+
+<c:set var="linkSignIn" value="false"/>
+<c:set var="linkSignOut" value="true"/>
+<c:set var="linkCreateAccount" value="false"/>
+<c:set var="linkBackToOsf" value="false"/>
+
+<jsp:directive.include file="default/ui/includes/bottom.jsp" />

--- a/cas-server-webapp/src/main/webapp/WEB-INF/view/jsp/errors.jsp
+++ b/cas-server-webapp/src/main/webapp/WEB-INF/view/jsp/errors.jsp
@@ -36,9 +36,10 @@
     }
 </script>
 
+<c:set var="linkSignOutandBackToSignIn" value="true"/>
 <c:set var="linkSignIn" value="false"/>
-<c:set var="linkSignOut" value="true"/>
+<c:set var="linkSignOut" value="false"/>
 <c:set var="linkCreateAccount" value="false"/>
-<c:set var="linkBackToOsf" value="false"/>
+<c:set var="linkBackToOsf" value="true"/>
 
 <jsp:directive.include file="default/ui/includes/bottom.jsp" />


### PR DESCRIPTION
## Ticket

https://openscience.atlassian.net/browse/SVCS-813

## Purpose

Fix 500s CAS Unavailable Page by Adding OSF Context

## Changes

### Before

![cas-unavailable-before](https://user-images.githubusercontent.com/3750414/39976938-9f3dc05e-5704-11e8-83bd-b0d732821d56.png)

### After

* Title Description

* Provide users with two options:
  * Return back to OSF with preserved OSF states
  * Clear CAS server state and return to the CAS sign in page 

![cas-unavailable-after](https://user-images.githubusercontent.com/3750414/39976950-b421ac6a-5704-11e8-92b8-2a58f5cb72cf.png)

## Side effects

Blocks: https://github.com/CenterForOpenScience/cas-overlay/pull/107

## QA Notes

No

## Deployment Notes

No
