### PR TITLE
[SVCS-812] Remove Deprecated Check for Ferris State Univ. from the Institution Login Page

### DIFF
--- a/cas-server-webapp/src/main/webapp/WEB-INF/view/jsp/default/ui/casInstitutionLoginView.jsp
+++ b/cas-server-webapp/src/main/webapp/WEB-INF/view/jsp/default/ui/casInstitutionLoginView.jsp
@@ -66,9 +66,6 @@
                 return;
             } else if (institutionLoginUrl === "callutheran") {
                 institutionLoginUrl = "${callutheranUrl}";
-            } else if (institutionLoginUrl === "ferris") {
-                // Disable institution login Ferris State University
-                return;
             } else if (institutionLoginUrl === "okstate") {
                 institutionLoginUrl = "${okstateUrl}";
             }


### PR DESCRIPTION

## Ticket

https://openscience.atlassian.net/browse/SVCS-812

## Purpose

The institution login page no longer needs extra check for Ferris State Univ. since https://github.com/CenterForOpenScience/osf.io/pull/8363 has been deployed. CAS no longer pulls Ferris from the database. The following check should be removed.

```javascript
else if (institutionLoginUrl === "ferris") {	
    // Disable institution login Ferris State University	
    return;	
} 
```

