### PR TITLE
[SVCS-837] Improve Exception Handling for Remote Principal Authentication

### DIFF
--- a/cas-server-support-osf/src/test/java/io/cos/cas/AbstractTestUtils.java
+++ b/cas-server-support-osf/src/test/java/io/cos/cas/AbstractTestUtils.java
@@ -1,8 +1,10 @@
 package io.cos.cas;
 
 import io.cos.cas.authentication.OpenScienceFrameworkCredential;
+
 import org.jasig.cas.authentication.principal.DefaultPrincipalFactory;
 import org.jasig.cas.authentication.principal.Principal;
+
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.mock.web.MockServletContext;
@@ -35,6 +37,8 @@ public abstract class AbstractTestUtils {
 
     public static final String CONST_NOT_EMPTY_STRING = "a_string_that_is_not_empty";
 
+    public static final String CONST_DISPLAY_NAME = "Jimmy Steward";
+
     private static final String REMOTE_USER = "REMOTE_USER";
 
     private static final String ATTRIBUTE_PREFIX = "AUTH-";
@@ -49,8 +53,6 @@ public abstract class AbstractTestUtils {
     private static final String CONST_GIVEN_NAME = "James";
 
     private static final String CONST_FAMILY_NAME = "Steward";
-
-    private static final String CONST_DISPLAY_NAME = "Jimmy Steward";
 
     public static Principal getPrincipal(final String name) {
         return new DefaultPrincipalFactory().createPrincipal(name, generateAttributesMap(""));

--- a/cas-server-support-osf/src/test/java/io/cos/cas/authentication/handler/support/OpenScienceFrameworkPrincipalFromRequestRemoteUserNonInteractiveCredentialsActionTests.java
+++ b/cas-server-support-osf/src/test/java/io/cos/cas/authentication/handler/support/OpenScienceFrameworkPrincipalFromRequestRemoteUserNonInteractiveCredentialsActionTests.java
@@ -6,10 +6,13 @@ import io.cos.cas.authentication.OpenScienceFrameworkCredential;
 import io.cos.cas.authentication.RemoteUserFailedLoginException;
 import io.cos.cas.mock.MockNormalizeRemotePrincipal;
 import io.cos.cas.mock.MockNotifyRemotePrincipalAuthenticated;
+
 import org.jasig.cas.CentralAuthenticationService;
 import org.jasig.cas.authentication.Authentication;
 import org.jasig.cas.ticket.TicketGrantingTicket;
+
 import org.junit.Test;
+
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.webflow.execution.Event;
 import org.springframework.webflow.test.MockRequestContext;
@@ -21,6 +24,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -43,25 +47,6 @@ public class OpenScienceFrameworkPrincipalFromRequestRemoteUserNonInteractiveCre
     private static final String CONST_ORCID_CLIENT_NAME = "OrcidClient";
 
     @Test (expected = RemoteUserFailedLoginException.class)
-    public void handleInstitutionMissingUsername() throws Exception {
-        final MockHttpServletRequest mockHttpServletRequest = AbstractTestUtils.getRequestWithShibbolethHeaders();
-        final MockRequestContext mockContext = AbstractTestUtils.getContextWithCredentials(mockHttpServletRequest);
-        final CentralAuthenticationService centralAuthenticationService = mock(CentralAuthenticationService.class);
-        final MockNormalizeRemotePrincipal osfRemoteAuthenticate
-                = new MockNormalizeRemotePrincipal(centralAuthenticationService);
-
-        final OpenScienceFrameworkCredential osfCredential = new OpenScienceFrameworkCredential();
-        osfCredential.setUsername("");
-        osfCredential.setInstitutionId(AbstractTestUtils.CONST_INSTITUTION_ID);
-        try {
-            osfRemoteAuthenticate.notifyRemotePrincipalAuthenticated(osfCredential);
-        } catch (final AccountException e) {
-            assertEquals(e.getMessage(), "Username (Email) Required");
-            throw e;
-        }
-    }
-
-    @Test (expected = RemoteUserFailedLoginException.class)
     public void handleInstitutionMissingInstitutionId() throws Exception {
         final MockHttpServletRequest mockHttpServletRequest = AbstractTestUtils.getRequestWithShibbolethHeaders();
         final MockRequestContext mockContext = AbstractTestUtils.getContextWithCredentials(mockHttpServletRequest);
@@ -75,7 +60,65 @@ public class OpenScienceFrameworkPrincipalFromRequestRemoteUserNonInteractiveCre
         try {
             osfRemoteAuthenticate.notifyRemotePrincipalAuthenticated(osfCredential);
         } catch (final AccountException e) {
-            assertEquals(e.getMessage(), "Institution Provider ID Required");
+            assertEquals(e.getMessage(), "Invalid remote principal: missing institution.");
+            throw e;
+        }
+    }
+
+    @Test (expected = RemoteUserFailedLoginException.class)
+    public void handleInstitutionMissingUsername() throws Exception {
+        final MockHttpServletRequest mockHttpServletRequest = AbstractTestUtils.getRequestWithShibbolethHeaders();
+        final MockRequestContext mockContext = AbstractTestUtils.getContextWithCredentials(mockHttpServletRequest);
+        final CentralAuthenticationService centralAuthenticationService = mock(CentralAuthenticationService.class);
+        final MockNormalizeRemotePrincipal osfRemoteAuthenticate
+                = new MockNormalizeRemotePrincipal(centralAuthenticationService);
+
+        final OpenScienceFrameworkCredential osfCredential = new OpenScienceFrameworkCredential();
+        osfCredential.setUsername("");
+        osfCredential.setInstitutionId(AbstractTestUtils.CONST_INSTITUTION_ID);
+        try {
+            osfRemoteAuthenticate.notifyRemotePrincipalAuthenticated(osfCredential);
+        } catch (final AccountException e) {
+            assertEquals(e.getMessage(), "Invalid remote principal: missing username.");
+            throw e;
+        }
+    }
+
+    @Test (expected = RemoteUserFailedLoginException.class)
+    public void handleInstitutionMissingNames() throws Exception {
+        final MockHttpServletRequest mockHttpServletRequest = AbstractTestUtils.getRequestWithShibbolethHeaders();
+        final MockRequestContext mockContext = AbstractTestUtils.getContextWithCredentials(mockHttpServletRequest);
+        final CentralAuthenticationService centralAuthenticationService = mock(CentralAuthenticationService.class);
+        final MockNormalizeRemotePrincipal osfRemoteAuthenticate
+                = new MockNormalizeRemotePrincipal(centralAuthenticationService);
+
+        final OpenScienceFrameworkCredential osfCredential = new OpenScienceFrameworkCredential();
+        osfCredential.setUsername(AbstractTestUtils.CONST_MAIL);
+        osfCredential.setInstitutionId(AbstractTestUtils.CONST_INSTITUTION_ID);
+        try {
+            osfRemoteAuthenticate.notifyRemotePrincipalAuthenticated(osfCredential);
+        } catch (final AccountException e) {
+            assertEquals(e.getMessage(), "Invalid remote principal: missing names.");
+            throw e;
+        }
+    }
+
+    @Test (expected = RemoteUserFailedLoginException.class)
+    public void handleInstitutionValidRemotePrincipal() throws Exception {
+        final MockHttpServletRequest mockHttpServletRequest = AbstractTestUtils.getRequestWithShibbolethHeaders();
+        final MockRequestContext mockContext = AbstractTestUtils.getContextWithCredentials(mockHttpServletRequest);
+        final CentralAuthenticationService centralAuthenticationService = mock(CentralAuthenticationService.class);
+        final MockNormalizeRemotePrincipal osfRemoteAuthenticate
+                = new MockNormalizeRemotePrincipal(centralAuthenticationService);
+        osfRemoteAuthenticate.setFullname(AbstractTestUtils.CONST_DISPLAY_NAME);
+
+        final OpenScienceFrameworkCredential osfCredential = new OpenScienceFrameworkCredential();
+        osfCredential.setUsername(AbstractTestUtils.CONST_MAIL);
+        osfCredential.setInstitutionId(AbstractTestUtils.CONST_INSTITUTION_ID);
+        try {
+            osfRemoteAuthenticate.notifyRemotePrincipalAuthenticated(osfCredential);
+        } catch (final AccountException e) {
+            assertEquals(e.getMessage(), "Failed to communicate with OSF API endpoint.");
             throw e;
         }
     }

--- a/cas-server-support-osf/src/test/java/io/cos/cas/mock/MockNormalizeRemotePrincipal.java
+++ b/cas-server-support-osf/src/test/java/io/cos/cas/mock/MockNormalizeRemotePrincipal.java
@@ -6,9 +6,6 @@ import org.jasig.cas.CentralAuthenticationService;
 
 import org.json.JSONObject;
 
-import javax.xml.parsers.ParserConfigurationException;
-import javax.xml.transform.TransformerException;
-
 /**
  * This class mocks the {@link OpenScienceFrameworkPrincipalFromRequestRemoteUserNonInteractiveCredentialsAction} class.
  *
@@ -17,22 +14,28 @@ import javax.xml.transform.TransformerException;
  */
 public class MockNormalizeRemotePrincipal extends MockOsfRemoteAuthenticateAction {
 
-    /** Constructor. */
+    private String fullname;
+
+    /** Default Constructor. */
     public MockNormalizeRemotePrincipal(final CentralAuthenticationService centralAuthenticationService) {
         super(centralAuthenticationService);
+        this.fullname = "";
     }
 
     @Override
-    protected JSONObject normalizeRemotePrincipal(final OpenScienceFrameworkCredential credential)
-            throws ParserConfigurationException, TransformerException {
+    protected JSONObject normalizeRemotePrincipal(final OpenScienceFrameworkCredential credential) {
 
         final JSONObject provider = new JSONObject();
         final JSONObject user = new JSONObject();
-
         user.put("username", credential.getUsername());
+        user.put("fullname", this.fullname);
         provider.put("id", credential.getInstitutionId());
         provider.put("user", user);
 
         return new JSONObject().put("provider", provider);
+    }
+
+    public void setFullname(final String fullname) {
+        this.fullname = fullname;
     }
 }

--- a/cas-server-support-osf/src/test/java/io/cos/cas/mock/MockOsfRemoteAuthenticateAction.java
+++ b/cas-server-support-osf/src/test/java/io/cos/cas/mock/MockOsfRemoteAuthenticateAction.java
@@ -1,6 +1,7 @@
 package io.cos.cas.mock;
 
 import io.cos.cas.authentication.handler.support.OpenScienceFrameworkPrincipalFromRequestRemoteUserNonInteractiveCredentialsAction;
+
 import org.jasig.cas.CentralAuthenticationService;
 
 /**
@@ -12,7 +13,7 @@ import org.jasig.cas.CentralAuthenticationService;
 public class MockOsfRemoteAuthenticateAction
     extends OpenScienceFrameworkPrincipalFromRequestRemoteUserNonInteractiveCredentialsAction {
 
-    protected static final String INSTITUTION_AUTH_URL = "http://institutionauth/";
+    protected static final String INSTITUTION_AUTH_URL = "institution_auth_url";
     protected static final String INSTITUTION_AUTH_JWE_SECRET = "osf_api_cas_login_jwe_secret_32b";
     protected static final String INSTITUTION_AUTH_JWT_SECRET = "osf_api_cas_login_jwt_secret_32b";
     protected static final String INSTITUTION_AUTH_XSL_LOCATION = "file:mock-institutions-auth.xsl";

--- a/cas-server-webapp/src/main/resources/messages.properties
+++ b/cas-server-webapp/src/main/resources/messages.properties
@@ -139,7 +139,7 @@ screen.shouldnothappen.message=Cannot login to an inactive account.  If you beli
 
 # Institution Login Failure Page
 screen.remoteuserfailedlogin.heading=Institution login failed
-screen.remoteuserfailedlogin.message=Please check with your institution to verify that your account is entitled to authenticate to OSF.
+screen.remoteuserfailedlogin.message=Please check with your institution to verify that your account is entitled to authenticate to OSF. If you believe this should not happen, please contact <a style="white-space: nowrap" href="mailto:support@osf.io">OSF Support</a>.
 
 # OAuth
 screen.oauth.confirm.header=Authorize application


### PR DESCRIPTION
## Ticket

https://openscience.atlassian.net/browse/SVCS-837

## Purpose

`notifyRemotePrincipalAuthenticated()` has a `try...catch...` that handles all the exceptions in one place. This makes logging and errors much less helpful/useful than it could/should be. In addition, it doesn't catch the error where "names" are not provided.

## Changes

This PR (1) splits the `try...catch...` and move them to handle independent functional parts (2) uses more specific error messages, (3) catches "missing names" errors instead of delegating this to OSF, (4) use `opt` instead of `get` to obtain JSON objects and strings to avoid `JSONException` and extra `if` statement. (5) Add/update tests to cover more cases.

## Side effects

No

## QA Notes

No

## Deployment Notes

No
