### PR TITLE
[No Ticket] Update source and target version from 1.7 to 1.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -728,8 +728,8 @@
         <cs.dir>${project.basedir}</cs.dir>
         <cas.properties.filepath>/WEB-INF/cas.properties</cas.properties.filepath>
         <maven.compiler.aspectj.skip>false</maven.compiler.aspectj.skip>
-        <project.build.sourceVersion>1.7</project.build.sourceVersion>
-        <project.build.targetVersion>1.7</project.build.targetVersion>
+        <project.build.sourceVersion>1.8</project.build.sourceVersion>
+        <project.build.targetVersion>1.8</project.build.targetVersion>
 
     </properties>
 </project>


### PR DESCRIPTION
### Purpose

Update maven project source and target version from 1.7 to 1.8.

Both the [Dockerfile](https://github.com/CenterForOpenScience/cas-overlay/blob/develop/Dockerfile) and [.travis.yml](https://github.com/CenterForOpenScience/cas-overlay/blob/b6b3297f9d46c0c5fe5e8e8fdcc95f8f449d9f72/.travis.yml) has been using Java8. We haven't had any know issues with 1.7-1.8 compatibility.

> Java SE 8 is strongly compatible with previous versions of the Java platform. Almost all
existing programs should run on Java SE 8 without modification. However, there are some
minor potential incompatibilities in the JRE and JDK that involve rare circumstances and
"corner cases" that are documented in the reference below for completeness. Ref: https://www.oracle.com/technetwork/java/javase/8-compatibility-guide-2156366.html
