### PR TITLE
[HotFix] Remove `member` from ORCiD API and update token URL

### DIFF
--- a/cas-server-support-osf/src/main/java/org/pac4j/oauth/client/OrcidClient.java
+++ b/cas-server-support-osf/src/main/java/org/pac4j/oauth/client/OrcidClient.java
@@ -120,12 +120,22 @@ public class OrcidClient extends BaseOAuth20Client<OrcidProfile> {
     @Override
     protected void internalInit() {
         super.internalInit();
-        this.service = new ProxyOAuth20ServiceImpl(new OrcidApi20(this.getMember()), new OAuthConfig(this.key,
-                this.secret,
-                this.callbackUrl,
-                SignatureType.Header,
-                this.getScope(),
-                null), this.connectTimeout, this.readTimeout, this.proxyHost, this.proxyPort, false, true);
+        this.service = new ProxyOAuth20ServiceImpl(
+                new OrcidApi20(),
+                new OAuthConfig(
+                        this.key,
+                        this.secret,
+                        this.callbackUrl,
+                        SignatureType.Header,
+                        this.getScope(),
+                        null
+                ),
+                this.connectTimeout,
+                this.readTimeout,
+                this.proxyHost, this.proxyPort,
+                false,
+                true
+        );
     }
 
     /**

--- a/cas-server-support-osf/src/main/java/org/scribe/builder/api/OrcidApi20.java
+++ b/cas-server-support-osf/src/main/java/org/scribe/builder/api/OrcidApi20.java
@@ -35,32 +35,19 @@ public class OrcidApi20 extends DefaultApi20 {
     private static final String AUTH_URL = "https://www.orcid.org/oauth/authorize";
 
     /** The token exchange url. */
-    private static final String TOKEN_URL = "https://%s.orcid.org/oauth/token";
-
-    /** The member flag. */
-    private final Boolean member;
+    private static final String TOKEN_URL = "https://orcid.org/oauth/token";
 
     /**
      * The default constructor.
      */
-    public OrcidApi20() {
-        this(Boolean.TRUE);
-    }
-
-    /**
-     * Create an instance of `OrcidApi20` with the `member` flag.
-     * @param member the member flag
-     */
-    public OrcidApi20(final Boolean member) {
-        this.member = member;
-    }
+    public OrcidApi20() {}
 
     /**
      * @return Return the url for token exchange endpoint.
      */
     @Override
     public String getAccessTokenEndpoint() {
-        return String.format(TOKEN_URL, (this.member ? "api" : "pub"));
+        return TOKEN_URL;
     }
 
     /**


### PR DESCRIPTION
## Ticket

Relates to but didn't fix the issue in https://openscience.atlassian.net/browse/ENG-1049

## Purpose

ORCiD has been in the process of deprecating `pub` and `api` endpoints and the root domain is far more reliable. This may explain why we are having ORCiD issue from time to time randomly.

Ref: https://members.orcid.org/api/news/xsd-20-update#5changes
> Token endpoints (the url used when exchanging an authorization code for an access token) are now simplified and are the same for public and member API: https://orcid.org/oauth/token|

Ref: https://members.orcid.org/api/news/use-root-url-when-requesting-oauth-tokens
> For example, calls to the public API url https://pub.orcid.org/oauth/token were rejected when the public API was down for two hours earlier this month, while the root url https://orcid.org/oauth/token remained available.

However, we are still using the `pub` one [here](https://github.com/CenterForOpenScience/cas-overlay/blob/develop/cas-server-support-osf/src/main/java/org/scribe/builder/api/OrcidApi20.java).

```java
private static final String TOKEN_URL = "https://%s.orcid.org/oauth/token";
@Override
public String getAccessTokenEndpoint() {
    return String.format(TOKEN_URL, (this.member ? "api" : "pub"));
}
```

[Here](https://github.com/pac4j/pac4j/commit/cfb5113300de914b6a6e5a109a87a9d1da576472#diff-6b048c3a376675b5a85a86d021f4e25eR21) is the latest `PAC4J` updates for this issue which we should follow.

## Changes

- Update the token URL to use the root domain: https://orcid.org/oauth/token 
- Remove deprecated `member` property for class `OrcidApi20`
- Please note the `member` is still a valid and functional property for class `OrcidClient`
- Style updates and comments/docstrings

## Side effects

No

## QA Notes

TBD or No

## Deployment Notes

No
