### PR TITLE
[SVCS-876] Correct button height and fix padding

### DIFF
--- a/cas-server-webapp/src/main/webapp/css/cas.css
+++ b/cas-server-webapp/src/main/webapp/css/cas.css
@@ -381,7 +381,7 @@ footer a:link, footer a:visited {
     -moz-border-radius: 4px;
     border-radius: 4px;
     display: inline-block;
-    padding: 15px 0 15px 0;
+    padding: 13px 0 13px 0;
     text-align: center;
 }
 
@@ -389,7 +389,7 @@ footer a:link, footer a:visited {
     font-size: 1.2em;
     opacity: 0.75;
     white-space: nowrap;
-    padding-left: 36px;
+    padding-left: 44px;
 }
 
 .row .btn-alt-login:hover {
@@ -410,7 +410,7 @@ footer a:link, footer a:visited {
     top: 0;
     border-right: 1px solid #ababab;
     padding: 6px;
-    height: 36px
+    height: 32px
 }
 
 #inst-login {
@@ -458,7 +458,7 @@ footer a:link, footer a:visited {
     color: white;
     font-weight: bold;
     width: 100%;
-    padding: 15px 2px 15px 2px;
+    padding: 14px 2px 14px 2px;
     -webkit-appearance: none;
     -moz-appearance: none;
     -webkit-border-radius: 3px;


### PR DESCRIPTION
### Ticket

Follow up PR for https://openscience.atlassian.net/browse/SVCS-876

### Purpose

Correct button height and fix padding.

### Changes

- Reduce ORCiD and OSF icon size from 36 to 32
- Correct Padding for button label: 44 = 32 + 6 + 6
- Correct padding for grey login buttons (ORCiD, Institution, OSF): 13
- Correct Padding for green login buttons (Email submit, 2FA submit): 14

### QA

<img width="1680" alt="new-vs-old" src="https://user-images.githubusercontent.com/3750414/43369896-fdb8c25c-9343-11e8-8128-3831e9e7bed1.png">
