### PR TITLE
[SVCS-884] Improve input fields for email and one-time passcode

### DIFF
--- a/cas-server-webapp/src/main/webapp/WEB-INF/view/jsp/default/ui/casLoginView.jsp
+++ b/cas-server-webapp/src/main/webapp/WEB-INF/view/jsp/default/ui/casLoginView.jsp
@@ -99,7 +99,7 @@
                 </c:when>
                 <c:otherwise>
                     <spring:message code="screen.welcome.label.netid.accesskey" var="userNameAccessKey"/>
-                    <form:input cssClass="required" cssErrorClass="error" id="username" size="25" tabindex="1" accesskey="${userNameAccessKey}" path="username" autocomplete="off" htmlEscape="true" placeholder="Email"/>
+                    <form:input type="email" cssClass="required" cssErrorClass="error" id="username" size="25" tabindex="1" accesskey="${userNameAccessKey}" path="username" autocomplete="off" htmlEscape="true" placeholder="Email"/>
                 </c:otherwise>
             </c:choose>
         </section>

--- a/cas-server-webapp/src/main/webapp/WEB-INF/view/jsp/default/ui/casOtpLoginView.jsp
+++ b/cas-server-webapp/src/main/webapp/WEB-INF/view/jsp/default/ui/casOtpLoginView.jsp
@@ -62,7 +62,7 @@
         <section class="row">
             <label for="oneTimePassword" style="display: none"><spring:message code="screen.welcome.label.passcode"/></label>
             <spring:message code="screen.welcome.label.passcode.accesskey" var="passcodeAccessKey"/>
-            <form:input cssClass="required" cssErrorClass="error" id="oneTimePassword" size="25" tabindex="1" accesskey="${passcodeAccessKey}" path="oneTimePassword" autocomplete="off" htmlEscape="true" placeholder="One time passcode"/>
+            <form:input cssClass="required" cssErrorClass="error" id="oneTimePassword" size="25" tabindex="1" accesskey="${passcodeAccessKey}" path="oneTimePassword" autocomplete="off" htmlEscape="true" pattern="[0-9]{6}" maxlength="6" placeholder="6-digit one-time passcode"/>
         </section>
         <form:errors path="*" id="msg" cssClass="errors" element="div" htmlEscape="false"/>
         <section class="row btn-row">

--- a/cas-server-webapp/src/main/webapp/css/cas.css
+++ b/cas-server-webapp/src/main/webapp/css/cas.css
@@ -231,7 +231,9 @@ header h1 {
     display: inline;
 }
 
-#login input[type=text], #login input[type=password] {
+#login input[type=text],
+#login input[type=email],
+#login input[type=password] {
     font-size: 1.4em;
     padding: 5px;
 }
@@ -334,6 +336,7 @@ footer a:link, footer a:visited {
 }
 
 #fm1 .row input[type=text],
+#fm1 .row input[type=email],
 #fm1 .row input[type=password] {
     width: 100%;
     padding: 10px;


### PR DESCRIPTION
## Ticket

https://openscience.atlassian.net/browse/SVCS-884

## Purpose

* Take advantage of `<input type="email">` to improve user experience on mobile/touch devices.
  * The email is first validated by the from
  * The "email keyboard" with `@` and `.` is provided to the user
* Add front-end validation for one-time passcode
  * The input must be 6 digits
  * User cannot enter more than 6 digits

## Changes

CAS uses Spring MVC and [here](https://docs.spring.io/spring/docs/current/spring-framework-reference/web.html#mvc-view-jsp-formtaglib-inputtag) is how it supports the input tag for HTML5. For detailed changes, please see the code/diff.
> Starting with Spring 3.1 you can use other types such HTML5-specific types like 'email', 'tel', 'date', and others.

## Side effects

No

## QA Notes

No

## Deployment Notes

No