### PR TITLE
[SVCS-889] Keep "REMOTE_USER" check in place for auth ID purpose

### DIFF
--- a/cas-server-support-osf/src/main/java/io/cos/cas/authentication/handler/support/OpenScienceFrameworkPrincipalFromRequestRemoteUserNonInteractiveCredentialsAction.java
+++ b/cas-server-support-osf/src/main/java/io/cos/cas/authentication/handler/support/OpenScienceFrameworkPrincipalFromRequestRemoteUserNonInteractiveCredentialsAction.java
@@ -312,6 +312,7 @@ public class OpenScienceFrameworkPrincipalFromRequestRemoteUserNonInteractiveCre
             final String remoteUser = request.getHeader(REMOTE_USER);
             if (StringUtils.isEmpty(remoteUser)) {
                 logger.error("Invalid Remote User specified as Empty");
+                // _TO_DO_: Delay the exception until we know which the institution is and who the user is.
                 throw new RemoteUserFailedLoginException("Invalid Remote User specified as Empty");
             }
             logger.info("Remote User from HttpServletRequest '{}'", remoteUser);


### PR DESCRIPTION
## Ticket

https://openscience.atlassian.net/browse/SVCS-889

## Purpose

### Main

Keep "REMOTE_USER" check in place for auth ID purpose

The header "REMOTE_USER" is still REQUIRED as an id for institution users although 1) OSF and CAS already rely on `username` for ID purpose and 2) `notifyRemotePrincipalAuthenticated()` guarantees that `username` is provided. The reason for keeping this extra check in place is that `username` is not always the identifier since it can be `eppn`, `mail` or other attributes. "REMOTE_USER" is defined as `REMOTE_USER="eppn uid persistent-id targeted-id"`, in which very
attribute can be considered as the users' institution identity. In short, CAS requires at least one of the four ID attributes `eppn`, `uid`, `persistent-id`, `targeted-id` in addition to attributes that are mapped to `username` and `fullname`. Please see our Shibboleth server's configuration (private) for detailed mapping for attributes. The following link provides the best practice of using "REMOTE_USER": https://wiki.shibboleth.net/confluence/display/SHIB2/NativeSPAttributeAccess

### More on **RMOTE_USER**

Here is a few quotes from the link provided above.

> "REMOTE_USER" is a special environment variable established by the CGI for use in passing the "authenticated username" to applications. It is NOT a header, and is designed to be set only when the web server is informed by a module that the user accessing the application is known. It is empty or unset otherwise.

> In some cases, the user's IdP may not provide enough information to uniquely identify the user, but instead supply only an attribute intended to grant the user access to something. Or it's possible that the user's own privacy requirements preclude supplying identifying information. In either case, the application might still have to run but will not have a username to key off of. This can certainly be treated as an error by the application. What it can't do is crash the application (unless you're fine with people thinking your site is designed by incompetents).

As discussed with @icereval , OSF institution login requires the user's institution identity. We choose to **treat the case as error** when attributes for "REMOTE_USER" is not provided.


## Changes

Only comments update.

## Side effects

No

## QA Notes

No

## Deployment Notes

No
