### PR TITLE
[PLAT-1055] Remove `is_claimed` from `OpenScienceFrameworkUser`

### DIFF
--- a/cas-server-support-osf/src/main/java/io/cos/cas/adaptors/postgres/handlers/OpenScienceFrameworkAuthenticationHandler.java
+++ b/cas-server-support-osf/src/main/java/io/cos/cas/adaptors/postgres/handlers/OpenScienceFrameworkAuthenticationHandler.java
@@ -237,7 +237,7 @@ public class OpenScienceFrameworkAuthenticationHandler extends AbstractPreAndPos
         } else {
             // If the user instance is not claimed, it is also not registered and not confirmed.
             // It can be either an unclaimed contributor or a new user pending confirmation.
-            if (!user.isClaimed() && !user.isRegistered() && !user.isConfirmed()) {
+            if (!user.isRegistered() && !user.isConfirmed()) {
                 if (isUnusablePassword(user.getPassword())) {
                     // If the user instance has an unusable password, it must be an unclaimed contributor.
                     logger.info("User Status Check: {}", USER_NOT_CLAIMED);

--- a/cas-server-support-osf/src/main/java/io/cos/cas/adaptors/postgres/handlers/OpenScienceFrameworkAuthenticationHandler.java
+++ b/cas-server-support-osf/src/main/java/io/cos/cas/adaptors/postgres/handlers/OpenScienceFrameworkAuthenticationHandler.java
@@ -211,32 +211,33 @@ public class OpenScienceFrameworkAuthenticationHandler extends AbstractPreAndPos
         return credential instanceof OpenScienceFrameworkCredential;
     }
 
-
-
     /**
-     * Verify User Status.
+     * Verify user status.
      *
-     *  USER_ACTIVE:
-     *      authentication succeed
-     *  USER_NOT_CONFIRMED:
-     *      inform the user that the account is not confirmed and provide a resend confirmation link
-     *  USER_DISABLED:
-     *      inform the user that the account is disable and that they can contact OSF support
-     *  USER_MERGED, USER_NOT_CLAIMED and USER_STATUS_UNKNOWN:
-     *      these is not suppose to happen, ask user to contact OSF support
+     * USER_ACTIVE:             Active user found, proceed.
+     *
+     * USER_NOT_CONFIRMED:      Inform users that the account is created but not confirmed. In addition, provide them
+     *                          with a link to resend confirmation email.
+     *
+     * USER_DISABLED:           Inform users that the account is disable and that they should contact OSF support.
+     *
+     * USER_MERGED,
+     * USER_NOT_CLAIMED,
+     * USER_STATUS_UNKNOWN:     These three are internal or invalid user status that are not supposed to happen with
+     *                          normal authentication and authorization flow.
      *
      * @param user the OSF user
      * @return the user status
      */
     private String verifyUserStatus(final OpenScienceFrameworkUser user) {
-        // An active user must be registered, claimed, not disabled, not merged and has a not null/None password.
-        // Only active user can pass the verification.
+        // An active user must be registered, not disabled, not merged and has a not null password.
+        // Only active users can pass the verification.
         if (user.isActive()) {
             logger.info("User Status Check: {}", USER_ACTIVE);
             return USER_ACTIVE;
         } else {
-            // If the user instance is not claimed, it is also not registered and not confirmed.
-            // It can be either an unclaimed contributor or a new user pending confirmation.
+            // If the user instance is neither registered nor not confirmed, it can be either an unclaimed contributor
+            // or a newly created user pending confirmation. The difference is whether it has a usable password.
             if (!user.isRegistered() && !user.isConfirmed()) {
                 if (isUnusablePassword(user.getPassword())) {
                     // If the user instance has an unusable password, it must be an unclaimed contributor.
@@ -249,23 +250,22 @@ public class OpenScienceFrameworkAuthenticationHandler extends AbstractPreAndPos
                     return USER_NOT_CONFIRMED;
                 }
             }
-            // If the user instance is merged by another user, it is registered, confirmed and claimed.
-            // `.merged_by` field being not null is a sufficient condition.
-            // However, its username is set to GUID and password is set to unusable.
+            // If the user instance has been merged by another user, it stays registered and confirmed. The username is
+            // GUID and the password is unusable. `.merged_by` being not null is a sufficient condition.
             if (user.isMerged()) {
                 logger.info("User Status Check: {}", USER_MERGED);
                 return USER_MERGED;
             }
-            // If the user instance is disabled, it is also not registered but claimed.
-            // `.date_disabled` field being not null is a sufficient condition.
-            // However, it still has the username and password.
-            // When the user tries to login, an account disabled message will be displayed.
+            // If the user instance is disabled, it is also not registered. `.date_disabled` being not null is a
+            // sufficient condition. It still has the original username and password. When the user tries to login with
+            // correct username and password, an "Account Disabled" message will be displayed.
             if (user.isDisabled()) {
                 logger.info("User Status Check: {}", USER_DISABLED);
                 return USER_DISABLED;
             }
 
-            // Other status combinations are considered UNKNOWN
+            // Other status combinations are considered UNKNOWN. This should not happen unless 1) there is bug in the
+            // user model and/or 2) the user model has been changed but CAS fails to catch up.
             logger.info("User Status Check: {}", USER_STATUS_UNKNOWN);
             return USER_STATUS_UNKNOWN;
         }

--- a/cas-server-support-osf/src/main/java/io/cos/cas/adaptors/postgres/models/OpenScienceFrameworkUser.java
+++ b/cas-server-support-osf/src/main/java/io/cos/cas/adaptors/postgres/models/OpenScienceFrameworkUser.java
@@ -66,9 +66,6 @@ public final class OpenScienceFrameworkUser {
     @Column(name = "is_registered", nullable = false)
     private Boolean registered;
 
-    @Column(name = "is_claimed", nullable = false)
-    private Boolean claimed;
-
     @Temporal(TemporalType.TIMESTAMP)
     @Column(name = "date_confirmed")
     private Date dateConfirmed;
@@ -106,10 +103,6 @@ public final class OpenScienceFrameworkUser {
 
     public Boolean isRegistered() {
         return registered;
-    }
-
-    public Boolean isClaimed() {
-        return claimed;
     }
 
     public Boolean isMerged() {


### PR DESCRIPTION
## Ticket

https://openscience.atlassian.net/browse/PLAT-1055

## Purpose

This is to keep in sync with the change to the OSF models made in https://github.com/CenterForOpenScience/osf.io/pull/8659

## Changes

- Remove references to `is_claimed` in user models

## Side effects

Hopefully not 🤞 

## QA Notes

No

## Deployment Notes

- [ ] @sloria and @icereval  This PR must be merged/deployed before https://github.com/CenterForOpenScience/osf.io/pull/8659 is merged/deployed. 
