### PR TITLE
[SVCS-926] Update JavaDocs For Customized Authentication Exceptions

### DIFF
--- a/cas-server-support-osf/src/main/java/io/cos/cas/authentication/LoginNotAllowedException.java
+++ b/cas-server-support-osf/src/main/java/io/cos/cas/authentication/LoginNotAllowedException.java
@@ -24,21 +24,20 @@ import javax.security.auth.login.AccountException;
  * Describes an error condition where authentication occurs from an registered but not confirmed account.
  *
  * @author Michael Haselton
- * @since 4.1.0
+ * @author Longze Chen
+ * @since 4.1.5
  */
 public class LoginNotAllowedException extends AccountException {
 
     private static final long serialVersionUID = 3376259469680697722L;
 
-    /**
-     * Instantiates a new invalid login location exception.
-     */
+    /** Instantiates a new exception (default). */
     public LoginNotAllowedException() {
         super();
     }
 
     /**
-     * Instantiates a new invalid login location exception.
+     * Instantiates a new exception with a given message.
      *
      * @param message the message
      */

--- a/cas-server-support-osf/src/main/java/io/cos/cas/authentication/OneTimePasswordFailedLoginException.java
+++ b/cas-server-support-osf/src/main/java/io/cos/cas/authentication/OneTimePasswordFailedLoginException.java
@@ -21,24 +21,23 @@ package io.cos.cas.authentication;
 import javax.security.auth.login.AccountException;
 
 /**
- * Describes an error condition where authentication occurs from an account which requires a Time-based One Time Password.
+ * Describes an error condition where two-factor authentication has failed.
  *
  * @author Michael Haselton
- * @since 4.1.0
+ * @author Longze Chen
+ * @since 4.1.5
  */
 public class OneTimePasswordFailedLoginException extends AccountException {
 
     private static final long serialVersionUID = 1973864633797308866L;
 
-    /**
-     * Instantiates a new invalid login location exception.
-     */
+    /** Instantiates a new exception (default). */
     public OneTimePasswordFailedLoginException() {
         super();
     }
 
     /**
-     * Instantiates a new invalid login location exception.
+     * Instantiates a new exception with a given message.
      *
      * @param message the message
      */

--- a/cas-server-support-osf/src/main/java/io/cos/cas/authentication/OneTimePasswordRequiredException.java
+++ b/cas-server-support-osf/src/main/java/io/cos/cas/authentication/OneTimePasswordRequiredException.java
@@ -21,24 +21,23 @@ package io.cos.cas.authentication;
 import javax.security.auth.login.AccountException;
 
 /**
- * Describes an error condition where authentication occurs from an account which requires a Time-based One Time Password.
+ * Describes an error condition where authentication occurs from an account which requires two-factor authentication.
  *
  * @author Michael Haselton
- * @since 4.1.0
+ * @author Longze Chen
+ * @since 4.1.5
  */
 public class OneTimePasswordRequiredException extends AccountException {
 
     private static final long serialVersionUID = -735616010527704206L;
 
-    /**
-     * Instantiates a new invalid login location exception.
-     */
+    /** Instantiates a new exception (default). */
     public OneTimePasswordRequiredException() {
         super();
     }
 
     /**
-     * Instantiates a new invalid login location exception.
+     * Instantiates a new exception with a given message.
      *
      * @param message the message
      */

--- a/cas-server-support-osf/src/main/java/io/cos/cas/authentication/RemoteUserFailedLoginException.java
+++ b/cas-server-support-osf/src/main/java/io/cos/cas/authentication/RemoteUserFailedLoginException.java
@@ -21,24 +21,23 @@ package io.cos.cas.authentication;
 import javax.security.auth.login.AccountException;
 
 /**
- * Describes an error condition where authentication occurs from an account which is merged.
+ * Describes an error condition where authentication has failed during authentication delegation.
  *
  * @author Michael Haselton
- * @since 4.1.0
+ * @author Longze Chen
+ * @since 4.1.5
  */
 public class RemoteUserFailedLoginException extends AccountException {
 
     private static final long serialVersionUID = 3472948140572518658L;
 
-    /**
-     * Instantiates a new remote user login failure exception.
-     */
+    /** Instantiates a new exception (default). */
     public RemoteUserFailedLoginException() {
         super();
     }
 
     /**
-     * Instantiates a new remote user login failure exception.
+     * Instantiates a new exception with a given message.
      *
      * @param message the message
      */

--- a/cas-server-support-osf/src/main/java/io/cos/cas/authentication/ShouldNotHappenException.java
+++ b/cas-server-support-osf/src/main/java/io/cos/cas/authentication/ShouldNotHappenException.java
@@ -22,26 +22,25 @@ import javax.security.auth.login.AccountException;
 
 /**
  * Describes an error condition where authentication occurs from an account that:
- * 1. unclaimed user which is created as an contributor
- * 2. merged user which is merged into antoher account
- * 3. other undefined user status (inactive and unknown)
+ *
+ * 1. is an unclaimed user which has been created as a new contributor
+ * 2. is an inactive user which has been merged into another account
+ * 3. has other undefined/unknown status, possibly due to internal bug or user model changes
  *
  * @author Longze Chen
- * @since 4.1.0
+ * @since 4.1.5
  */
 public class ShouldNotHappenException extends AccountException {
 
     private static final long serialVersionUID = 8296529645368130304L;
 
-    /**
-     * Instantiates a new invalid login location exception.
-     */
+    /** Instantiates a new exception (default). */
     public ShouldNotHappenException() {
         super();
     }
 
     /**
-     * Instantiates a new invalid login location exception.
+     * Instantiates a new exception with a given message.
      *
      * @param message the message
      */


### PR DESCRIPTION
## Ticket

https://openscience.atlassian.net/browse/SVCS-926

## Purpose

JavaDocs (DocStrs) and comments are incorrect due to copy-paste for all customized authentication exceptions. This PR fixes them.

## Changes

* LoginNotAllowedException
* OneTimePasswordFailedLoginException
* OneTimePasswordRequiredException
* RemoteUserFailedLoginException
* ShouldNotHappenException


## Side effects

No

## QA Notes

No

## Deployment Notes

No
