### PR TITLE
[ENG-316] Update Token-Scope Relationships

### DIFF
--- a/cas-server-support-osf/src/main/java/io/cos/cas/adaptors/postgres/daos/OpenScienceFrameworkDao.java
+++ b/cas-server-support-osf/src/main/java/io/cos/cas/adaptors/postgres/daos/OpenScienceFrameworkDao.java
@@ -78,6 +78,14 @@ public interface OpenScienceFrameworkDao {
     OpenScienceFrameworkApiOauth2Scope findOneScopeByName(final String name);
 
     /**
+     * Find one scope by id (i.e. the primary key, not the scopeId).
+     *
+     * @param id the primary key
+     * @return OpenScienceFrameworkApiOauth2Scope or null
+     */
+    OpenScienceFrameworkApiOauth2Scope findOneScopeById(final Integer id);
+
+    /**
      * Find one personal access token by token id.
      *
      * @param tokenId the token id

--- a/cas-server-support-osf/src/main/java/io/cos/cas/adaptors/postgres/daos/OpenScienceFrameworkDao.java
+++ b/cas-server-support-osf/src/main/java/io/cos/cas/adaptors/postgres/daos/OpenScienceFrameworkDao.java
@@ -22,6 +22,7 @@ package io.cos.cas.adaptors.postgres.daos;
 import io.cos.cas.adaptors.postgres.models.OpenScienceFrameworkApiOauth2Application;
 import io.cos.cas.adaptors.postgres.models.OpenScienceFrameworkApiOauth2PersonalAccessToken;
 import io.cos.cas.adaptors.postgres.models.OpenScienceFrameworkApiOauth2Scope;
+import io.cos.cas.adaptors.postgres.models.OpenScienceFrameworkApiOauth2TokenScope;
 import io.cos.cas.adaptors.postgres.models.OpenScienceFrameworkGuid;
 import io.cos.cas.adaptors.postgres.models.OpenScienceFrameworkInstitution;
 import io.cos.cas.adaptors.postgres.models.OpenScienceFrameworkTimeBasedOneTimePassword;
@@ -92,10 +93,18 @@ public interface OpenScienceFrameworkDao {
     List<OpenScienceFrameworkApiOauth2Application> findOauthApplications();
 
     /**
-     * Find the GUID object asscociated with a User.
+     * Find the guid object associated with the user.
      *
      * @param user the user
      * @return the GUID object
      */
     OpenScienceFrameworkGuid findGuidByUser(final OpenScienceFrameworkUser user);
+
+    /**
+     * Fine all the token-scope relationships by the token's primary key (GUID).
+     *
+     * @param tokenGuid the token's primary key (GUID)
+     * @return OpenScienceFrameworkApiOauth2TokenScope List or null
+     */
+    List<OpenScienceFrameworkApiOauth2TokenScope> findAllTokenScopesByTokenGuid(final Integer tokenGuid);
 }

--- a/cas-server-support-osf/src/main/java/io/cos/cas/adaptors/postgres/daos/OpenScienceFrameworkDao.java
+++ b/cas-server-support-osf/src/main/java/io/cos/cas/adaptors/postgres/daos/OpenScienceFrameworkDao.java
@@ -78,15 +78,15 @@ public interface OpenScienceFrameworkDao {
     OpenScienceFrameworkApiOauth2Scope findOneScopeByName(final String name);
 
     /**
-     * Find one scope by id (i.e. the primary key, not the scopeId).
+     * Find one scope by the scope's primary key id.
      *
-     * @param id the primary key
+     * @param scopePk the scope's primary key
      * @return OpenScienceFrameworkApiOauth2Scope or null
      */
-    OpenScienceFrameworkApiOauth2Scope findOneScopeById(final Integer id);
+    OpenScienceFrameworkApiOauth2Scope findOneScopeByScopePk(final Integer scopePk);
 
     /**
-     * Find one personal access token by token id.
+     * Find one personal access token by token id (i.e the column token_id, not the primary key id).
      *
      * @param tokenId the token id
      * @return OpenScienceFrameworkApiOauth2PersonalAccessToken or null
@@ -109,10 +109,10 @@ public interface OpenScienceFrameworkDao {
     OpenScienceFrameworkGuid findGuidByUser(final OpenScienceFrameworkUser user);
 
     /**
-     * Fine all the token-scope relationships by the token's primary key (GUID).
+     * Fine all the token-scope relationships by the token's primary key.
      *
-     * @param tokenGuid the token's primary key (GUID)
+     * @param tokenPk the token's primary key
      * @return OpenScienceFrameworkApiOauth2TokenScope List or null
      */
-    List<OpenScienceFrameworkApiOauth2TokenScope> findAllTokenScopesByTokenGuid(final Integer tokenGuid);
+    List<OpenScienceFrameworkApiOauth2TokenScope> findAllTokenScopesByTokenPk(final Integer tokenPk);
 }

--- a/cas-server-support-osf/src/main/java/io/cos/cas/adaptors/postgres/daos/OpenScienceFrameworkDaoImpl.java
+++ b/cas-server-support-osf/src/main/java/io/cos/cas/adaptors/postgres/daos/OpenScienceFrameworkDaoImpl.java
@@ -169,6 +169,20 @@ public class OpenScienceFrameworkDaoImpl implements OpenScienceFrameworkDao {
     }
 
     @Override
+    public OpenScienceFrameworkApiOauth2Scope findOneScopeById(final Integer id) {
+        try {
+            final TypedQuery<OpenScienceFrameworkApiOauth2Scope> query = entityManager.createQuery(
+                    "select s from OpenScienceFrameworkApiOauth2Scope s where s.id = :id",
+                    OpenScienceFrameworkApiOauth2Scope.class
+            );
+            query.setParameter("id", id);
+            return query.getSingleResult();
+        } catch (final PersistenceException e) {
+            return null;
+        }
+    }
+
+    @Override
     public OpenScienceFrameworkApiOauth2PersonalAccessToken findOnePersonalAccessTokenByTokenId(final String tokenId) {
         try {
             final TypedQuery<OpenScienceFrameworkApiOauth2PersonalAccessToken> query = entityManager.createQuery(

--- a/cas-server-support-osf/src/main/java/io/cos/cas/adaptors/postgres/daos/OpenScienceFrameworkDaoImpl.java
+++ b/cas-server-support-osf/src/main/java/io/cos/cas/adaptors/postgres/daos/OpenScienceFrameworkDaoImpl.java
@@ -22,6 +22,7 @@ package io.cos.cas.adaptors.postgres.daos;
 import io.cos.cas.adaptors.postgres.models.OpenScienceFrameworkApiOauth2Application;
 import io.cos.cas.adaptors.postgres.models.OpenScienceFrameworkApiOauth2PersonalAccessToken;
 import io.cos.cas.adaptors.postgres.models.OpenScienceFrameworkApiOauth2Scope;
+import io.cos.cas.adaptors.postgres.models.OpenScienceFrameworkApiOauth2TokenScope;
 import io.cos.cas.adaptors.postgres.models.OpenScienceFrameworkEmail;
 import io.cos.cas.adaptors.postgres.models.OpenScienceFrameworkGuid;
 import io.cos.cas.adaptors.postgres.models.OpenScienceFrameworkInstitution;
@@ -209,6 +210,20 @@ public class OpenScienceFrameworkDaoImpl implements OpenScienceFrameworkDao {
             query.setParameter("appLable", "osf");
             query.setParameter("model", "osfuser");
             return query.getSingleResult();
+        } catch (final PersistenceException e) {
+            return null;
+        }
+    }
+
+    @Override
+    public List<OpenScienceFrameworkApiOauth2TokenScope> findAllTokenScopesByTokenGuid(final Integer tokenGuid) {
+        try {
+            final TypedQuery<OpenScienceFrameworkApiOauth2TokenScope> query = entityManager.createQuery(
+                    "select m from OpenScienceFrameworkApiOauth2TokenScope m where m.tokenGuid = :tokenGuid",
+                    OpenScienceFrameworkApiOauth2TokenScope.class
+            );
+            query.setParameter("tokenGuid", tokenGuid);
+            return query.getResultList();
         } catch (final PersistenceException e) {
             return null;
         }

--- a/cas-server-support-osf/src/main/java/io/cos/cas/adaptors/postgres/daos/OpenScienceFrameworkDaoImpl.java
+++ b/cas-server-support-osf/src/main/java/io/cos/cas/adaptors/postgres/daos/OpenScienceFrameworkDaoImpl.java
@@ -169,13 +169,13 @@ public class OpenScienceFrameworkDaoImpl implements OpenScienceFrameworkDao {
     }
 
     @Override
-    public OpenScienceFrameworkApiOauth2Scope findOneScopeById(final Integer id) {
+    public OpenScienceFrameworkApiOauth2Scope findOneScopeByScopePk(final Integer scopePk) {
         try {
             final TypedQuery<OpenScienceFrameworkApiOauth2Scope> query = entityManager.createQuery(
                     "select s from OpenScienceFrameworkApiOauth2Scope s where s.id = :id",
                     OpenScienceFrameworkApiOauth2Scope.class
             );
-            query.setParameter("id", id);
+            query.setParameter("id", scopePk);
             return query.getSingleResult();
         } catch (final PersistenceException e) {
             return null;
@@ -230,13 +230,13 @@ public class OpenScienceFrameworkDaoImpl implements OpenScienceFrameworkDao {
     }
 
     @Override
-    public List<OpenScienceFrameworkApiOauth2TokenScope> findAllTokenScopesByTokenGuid(final Integer tokenGuid) {
+    public List<OpenScienceFrameworkApiOauth2TokenScope> findAllTokenScopesByTokenPk(final Integer tokenPk) {
         try {
             final TypedQuery<OpenScienceFrameworkApiOauth2TokenScope> query = entityManager.createQuery(
-                    "select m from OpenScienceFrameworkApiOauth2TokenScope m where m.tokenGuid = :tokenGuid",
+                    "select m from OpenScienceFrameworkApiOauth2TokenScope m where m.tokenPk = :tokenPk",
                     OpenScienceFrameworkApiOauth2TokenScope.class
             );
-            query.setParameter("tokenGuid", tokenGuid);
+            query.setParameter("tokenPk", tokenPk);
             return query.getResultList();
         } catch (final PersistenceException e) {
             return null;

--- a/cas-server-support-osf/src/main/java/io/cos/cas/adaptors/postgres/handlers/OpenScienceFrameworkPersonalAccessTokenHandler.java
+++ b/cas-server-support-osf/src/main/java/io/cos/cas/adaptors/postgres/handlers/OpenScienceFrameworkPersonalAccessTokenHandler.java
@@ -44,7 +44,7 @@ import java.util.Set;
  *
  * @author Michael Haselton
  * @author Longze Chen
- * @since 4.1.0
+ * @since 4.1.5
  */
 public class OpenScienceFrameworkPersonalAccessTokenHandler extends AbstractPersonalAccessTokenHandler
         implements InitializingBean {
@@ -80,7 +80,6 @@ public class OpenScienceFrameworkPersonalAccessTokenHandler extends AbstractPers
         // Find the scopes associated with this token
         final List<OpenScienceFrameworkApiOauth2TokenScope> tokenScopeList
                 = openScienceFrameworkDao.findAllTokenScopesByTokenPk(token.getId());
-        LOGGER.info(tokenScopeList.toString());
         final Set<String> scopeSet = new HashSet<>();
         for (final OpenScienceFrameworkApiOauth2TokenScope tokenScope : tokenScopeList) {
             final OpenScienceFrameworkApiOauth2Scope scope
@@ -89,7 +88,6 @@ public class OpenScienceFrameworkPersonalAccessTokenHandler extends AbstractPers
                 scopeSet.add(scope.getName());
             }
         }
-        LOGGER.info(scopeSet.toString());
 
         // Find the owner of the token
         final OpenScienceFrameworkGuid guid = openScienceFrameworkDao.findGuidByUser(token.getOwner());
@@ -97,6 +95,7 @@ public class OpenScienceFrameworkPersonalAccessTokenHandler extends AbstractPers
             return null;
         }
 
+        // Return a PAT of the CAS model, which is created based on the token, scope and owner of the OSF model.
         return new PersonalAccessToken(token.getTokenId(), guid.getGuid(), scopeSet);
     }
 }

--- a/cas-server-support-osf/src/main/java/io/cos/cas/adaptors/postgres/handlers/OpenScienceFrameworkPersonalAccessTokenHandler.java
+++ b/cas-server-support-osf/src/main/java/io/cos/cas/adaptors/postgres/handlers/OpenScienceFrameworkPersonalAccessTokenHandler.java
@@ -79,15 +79,17 @@ public class OpenScienceFrameworkPersonalAccessTokenHandler extends AbstractPers
 
         // Find the scopes associated with this token
         final List<OpenScienceFrameworkApiOauth2TokenScope> tokenScopeList
-                = openScienceFrameworkDao.findAllTokenScopesByTokenGuid(token.getId());
+                = openScienceFrameworkDao.findAllTokenScopesByTokenPk(token.getId());
+        LOGGER.info(tokenScopeList.toString());
         final Set<String> scopeSet = new HashSet<>();
         for (final OpenScienceFrameworkApiOauth2TokenScope tokenScope : tokenScopeList) {
             final OpenScienceFrameworkApiOauth2Scope scope
-                    = openScienceFrameworkDao.findOneScopeById(tokenScope.getScopeGuid());
+                    = openScienceFrameworkDao.findOneScopeByScopePk(tokenScope.getScopePk());
             if (scope != null) {
                 scopeSet.add(scope.getName());
             }
         }
+        LOGGER.info(scopeSet.toString());
 
         // Find the owner of the token
         final OpenScienceFrameworkGuid guid = openScienceFrameworkDao.findGuidByUser(token.getOwner());

--- a/cas-server-support-osf/src/main/java/io/cos/cas/adaptors/postgres/models/OpenScienceFrameworkApiOauth2PersonalAccessToken.java
+++ b/cas-server-support-osf/src/main/java/io/cos/cas/adaptors/postgres/models/OpenScienceFrameworkApiOauth2PersonalAccessToken.java
@@ -31,7 +31,7 @@ import javax.persistence.Table;
  *
  * @author Michael Haselton
  * @author Longze Chen
- * @since 4.1.0
+ * @since 4.1.5
  */
 @Entity
 @Table(name = "osf_apioauth2personaltoken")
@@ -46,9 +46,6 @@ public class OpenScienceFrameworkApiOauth2PersonalAccessToken {
 
     @Column(name = "name", nullable = false)
     private String name;
-
-    @Column(name = "scopes", nullable = false)
-    private String scopes;
 
     @Column(name = "is_active", nullable = false)
     private Boolean isActive;
@@ -70,10 +67,6 @@ public class OpenScienceFrameworkApiOauth2PersonalAccessToken {
 
     public String getName() {
         return name;
-    }
-
-    public String getScopes() {
-        return scopes;
     }
 
     public Boolean isActive() {

--- a/cas-server-support-osf/src/main/java/io/cos/cas/adaptors/postgres/models/OpenScienceFrameworkApiOauth2Scope.java
+++ b/cas-server-support-osf/src/main/java/io/cos/cas/adaptors/postgres/models/OpenScienceFrameworkApiOauth2Scope.java
@@ -29,7 +29,7 @@ import javax.persistence.Table;
  *
  * @author Michael Haselton
  * @author Longze Chen
- * @since 4.1.0
+ * @since 4.1.5
  */
 @Entity
 @Table(name = "osf_apioauth2scope")
@@ -38,6 +38,9 @@ public class OpenScienceFrameworkApiOauth2Scope {
     @Id
     @Column(name = "id", nullable = false)
     private Integer id;
+
+    @Column(name = "_id", nullable = false)
+    private String scopeId;
 
     @Column(name = "name", nullable = false)
     private String name;
@@ -48,12 +51,19 @@ public class OpenScienceFrameworkApiOauth2Scope {
     @Column(name = "is_active", nullable = false)
     private Boolean isActive;
 
+    @Column(name = "is_public", nullable = false)
+    private Boolean isPublic;
+
     /** Default Constructor. */
     public OpenScienceFrameworkApiOauth2Scope() {}
 
 
     public Integer getId() {
         return id;
+    }
+
+    public String getScopeId() {
+        return scopeId;
     }
 
     public String getName() {
@@ -66,6 +76,10 @@ public class OpenScienceFrameworkApiOauth2Scope {
 
     public Boolean isActive() {
         return isActive;
+    }
+
+    public Boolean isPublic() {
+        return isPublic;
     }
 
     @Override

--- a/cas-server-support-osf/src/main/java/io/cos/cas/adaptors/postgres/models/OpenScienceFrameworkApiOauth2TokenScope.java
+++ b/cas-server-support-osf/src/main/java/io/cos/cas/adaptors/postgres/models/OpenScienceFrameworkApiOauth2TokenScope.java
@@ -41,11 +41,11 @@ public class OpenScienceFrameworkApiOauth2TokenScope {
 
     /** The Primary Key of the Personal Access Token Object. */
     @Column(name = "apioauth2personaltoken_id", nullable = false)
-    private Integer tokenGuid;
+    private Integer tokenPk;
 
     /** The Primary Key of the Scope Object. */
     @Column(name = "apioauth2scope_id", nullable = false)
-    private Integer scopeGuid;
+    private Integer scopePk;
 
     /** The Default Constructor. */
     public OpenScienceFrameworkApiOauth2TokenScope() {}
@@ -54,16 +54,16 @@ public class OpenScienceFrameworkApiOauth2TokenScope {
         return id;
     }
 
-    public Integer getTokenGuid() {
-        return tokenGuid;
+    public Integer getTokenPk() {
+        return tokenPk;
     }
 
-    public Integer getScopeGuid() {
-        return scopeGuid;
+    public Integer getScopePk() {
+        return scopePk;
     }
 
     @Override
     public String toString() {
-        return String.format("OpenScienceFrameworkApiOauth2TokenScope [tokenGuid=%s, scopeGuid=%d, ]", tokenGuid, scopeGuid);
+        return String.format("OpenScienceFrameworkApiOauth2TokenScope [tokenPk=%s, scopePk=%d, ]", tokenPk, scopePk);
     }
 }

--- a/cas-server-support-osf/src/main/java/io/cos/cas/adaptors/postgres/models/OpenScienceFrameworkApiOauth2TokenScope.java
+++ b/cas-server-support-osf/src/main/java/io/cos/cas/adaptors/postgres/models/OpenScienceFrameworkApiOauth2TokenScope.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to Jasig under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work
+ * for additional information regarding copyright ownership.
+ * Jasig licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License.  You may obtain a
+ * copy of the License at the following location:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.cos.cas.adaptors.postgres.models;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Table;
+
+/**
+ * The M2M Relationship between OSF API OAuth2 "Personal Access Token" and "Scope".
+ *
+ * @author Longze Chen
+ * @since 4.1.5
+ */
+@Entity
+@Table(name = "osf_apioauth2personaltoken_scopes")
+public class OpenScienceFrameworkApiOauth2TokenScope {
+
+    /** The Primary Key. */
+    @Id
+    @Column(name = "id", nullable = false)
+    private Integer id;
+
+    /** The Primary Key of the Personal Access Token Object. */
+    @Column(name = "apioauth2personaltoken_id", nullable = false)
+    private Integer tokenGuid;
+
+    /** The Primary Key of the Scope Object. */
+    @Column(name = "apioauth2scope_id", nullable = false)
+    private Integer scopeGuid;
+
+    /** The Default Constructor. */
+    public OpenScienceFrameworkApiOauth2TokenScope() {}
+
+    public Integer getId() {
+        return id;
+    }
+
+    public Integer getTokenGuid() {
+        return tokenGuid;
+    }
+
+    public Integer getScopeGuid() {
+        return scopeGuid;
+    }
+
+    @Override
+    public String toString() {
+        return String.format("OpenScienceFrameworkApiOauth2TokenScope [tokenGuid=%s, scopeGuid=%d, ]", tokenGuid, scopeGuid);
+    }
+}

--- a/cas-server-support-osf/src/main/java/io/cos/cas/adaptors/postgres/models/OpenScienceFrameworkDjangoContentTypeId.java
+++ b/cas-server-support-osf/src/main/java/io/cos/cas/adaptors/postgres/models/OpenScienceFrameworkDjangoContentTypeId.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to Jasig under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work
+ * for additional information regarding copyright ownership.
+ * Jasig licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License.  You may obtain a
+ * copy of the License at the following location:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package io.cos.cas.adaptors.postgres.models;
 
 import javax.persistence.Column;

--- a/cas-server-support-osf/src/main/java/io/cos/cas/adaptors/postgres/models/OpenScienceFrameworkEmail.java
+++ b/cas-server-support-osf/src/main/java/io/cos/cas/adaptors/postgres/models/OpenScienceFrameworkEmail.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to Jasig under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work
+ * for additional information regarding copyright ownership.
+ * Jasig licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License.  You may obtain a
+ * copy of the License at the following location:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package io.cos.cas.adaptors.postgres.models;
 
 import javax.persistence.Column;

--- a/cas-server-support-osf/src/main/java/io/cos/cas/adaptors/postgres/models/OpenScienceFrameworkGuid.java
+++ b/cas-server-support-osf/src/main/java/io/cos/cas/adaptors/postgres/models/OpenScienceFrameworkGuid.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to Jasig under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work
+ * for additional information regarding copyright ownership.
+ * Jasig licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License.  You may obtain a
+ * copy of the License at the following location:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package io.cos.cas.adaptors.postgres.models;
 
 import javax.persistence.Column;


### PR DESCRIPTION
## Ticket

https://openscience.atlassian.net/browse/ENG-316

## Purpose

Update Token-Scope Relationships

## Changes

### Primary Changes

* Add M2M relationship between PAT and scope. OSF implements many-to-many relationship by using a third "joining" or "bridging" table that maps PAT and scope.
* Add `scopeId` and `isPublic` to the scope model
* Remove `scopes` from the PAT model
* Update OSF DAO & its Implementation to query token-scope by token's PK and to query scope by scope's PK
* Update PAT handler

### Other

* Add missing license for a few models

## Side effects

No

## QA Notes

Please test this on stagings and prod with CenterForOpenScience/osf.io#8766.

## Deployment Notes

- [ ] Must be merged into develop and released to master at the same time with CenterForOpenScience/osf.io#8766.

- [x] No migration needs to run on the CAS side since CAS  internal AT model remains the same.
