### PR TITLE
[HotFix] [SVCS-946] Support OSF Signup via ORCiD

### DIFF
--- a/cas-server-webapp/src/main/webapp/WEB-INF/view/jsp/default/ui/casOrcidLoginRedirectView.jsp
+++ b/cas-server-webapp/src/main/webapp/WEB-INF/view/jsp/default/ui/casOrcidLoginRedirectView.jsp
@@ -1,0 +1,25 @@
+<%--
+
+    Licensed to Apereo under one or more contributor license
+    agreements. See the NOTICE file distributed with this work
+    for additional information regarding copyright ownership.
+    Apereo licenses this file to you under the Apache License,
+    Version 2.0 (the "License"); you may not use this file
+    except in compliance with the License.  You may obtain a
+    copy of the License at the following location:
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+--%>
+
+<%-- ORCiD Login Redirect Page --%>
+
+<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<c:redirect url="${OrcidClientUrl}"/>

--- a/cas-server-webapp/src/main/webapp/WEB-INF/webflow/login/login-webflow.xml
+++ b/cas-server-webapp/src/main/webapp/WEB-INF/webflow/login/login-webflow.xml
@@ -103,6 +103,7 @@
         <evaluate expression="loginHandler.beforeLogin(flowRequestContext)" />
         <transition on="osfDefaultLogin" to="viewLoginForm" />
         <transition on="institutionLogin" to="osfInstitutionLogin" />
+        <transition on="orcidLoginRedirect" to="viewOrcidLoginRedirectPage" />
     </action-state>
 
     <action-state id="osfInstitutionLogin">
@@ -111,6 +112,9 @@
     </action-state>
 
     <view-state id="viewInstitutionLoginForm" view="casInstitutionLoginView" model="credential">
+    </view-state>
+
+    <view-state id="viewOrcidLoginRedirectPage" view="casOrcidLoginRedirectView" model="credential">
     </view-state>
 
     <view-state id="viewLoginForm" view="casLoginView" model="credential">


### PR DESCRIPTION
## Ticket

https://openscience.atlassian.net/browse/SVCS-946

## Purpose

Update login handler to support sign up via ORCiD for OSF. CAS checks the redirectOrcid param in the login URL and returns the web flow to a dedicated view for ORCiD login redirect. In this way, the required service is generated first before ORCiD OAuth. Upon successful login, CAS can redirect users back to expected OSF pages.

## Changes

Please refer to the diff.

## Side effects

No

## QA Notes

- [ ] Please test this with [please add a platform and/or emberosf ticket here]().
- [ ] **Optional** Please test that normal CAS actions works as expected.

## Deployment Notes

- [ ] This must be released and deployed before [please add a platform and/or emberosf release here]()
