### PR TITLE
[No Ticket] Fix oraclejdk8 build failure on travis due to xenial as default

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@
 #
 
 language: java
+dist: trusty
 sudo: false
 jdk:
   - oraclejdk8


### PR DESCRIPTION
## Purpose and Changes

Fix build failure on travis due to `xenial` as the new default env. Travis CI changed their default build env [from `trusty` to `xenial`](https://changelog.travis-ci.com/xenial-as-the-default-build-environment-99476). This breaks the build for `oraclejdk8` on travis. Explicitly setting `dist` to `trusty` in the `.travis.yml` fixes the problem.

