### PR TITLE
[ENG-849] Update Travis CI to use `openjdk8` instead of `oraclejdk8`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ language: java
 dist: trusty
 sudo: false
 jdk:
-  - oraclejdk8
+  - openjdk8
 cache:
   directories:
     - '$HOME/.m2/repository'


### PR DESCRIPTION
## Ticket

[ENG-849](https://openscience.atlassian.net/browse/ENG-849)

## Purpose

Switch travis build to use openjdk8.

## Changes

Prefer openjdk8 over oraclejdk8 in travis.  Dockerfile is already based off openjdk8 via [`jetty:9.3-jre8-alpine`](https://github.com/appropriate/docker-jetty/blob/master/9.3-jre8/alpine/Dockerfile) and `maven:3.3-jdk-8`.

## QA Notes

No QA needed, only affects travis.

## Deployment Notes

None.  Travis-only fix.

## Documentation

None.

## Side effects

None expected.
