### PR TITLE
[ENG-866] [OSF Institutions] Update `institutions-auth.xsl` for UNC

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -12,8 +12,8 @@
 
 ## Ticket
 
-<!-- Link to the JIRA ticket(s), if applicable. For example:
-     [ENG-000](https://openscience.atlassian.net/browse/SVCS-000)
+<!-- Link to the JIRA ticket, if applicable. For example:
+     [ENG-000](https://openscience.atlassian.net/browse/ENG-000)
 -->
 
 ## Purpose
@@ -26,9 +26,9 @@
 
 ## Dev / QA Notes
 
-<!-- This section is required if this change needs QA. -->
+<!-- Any special note for local development and/or QA testing? -->
 
 ## Dev-Ops Notes
 
-<!-- Any special configurations for deployment? -->
+<!-- Any special note for PR merge and/or server deployment? -->
 

--- a/etc/institutions-auth.xsl
+++ b/etc/institutions-auth.xsl
@@ -9,17 +9,17 @@
     <xsl:template match="auth">
         <xsl:variable name="delegation-protocol" select="//attribute[@name='Delegation-Protocol']/@value" />
         <xsl:choose>
-            <!--  Institutions that use Shibboleth for Authentication  -->
+            <!--  Institutions that use the SAML protocol for Authentication  -->
             <xsl:when test="$delegation-protocol = 'saml-shib'">
                 <xsl:variable name="idp" select="//attribute[@name='Shib-Identity-Provider']/@value" />
                 <idp><xsl:value-of select="$idp"/></idp>
                 <xsl:choose>
-                    <!--  Example Shib University -->
-                    <xsl:when test="$idp='https://login.exampleshibuniv.edu/idp/shibboleth'">
+                    <!--  Example SAML-auth University -->
+                    <xsl:when test="$idp='example-shib-auth-univeristy-entity-id'">
                         <id>esu</id>
                         <user>
-                            <!--  Each institution has customized mapping of attributes  -->
-                            <username><xsl:value-of select="//attribute[@name='mail']/@value"/></username>
+                            <!--  Each institution has its customized mapping of attributes  -->
+                            <username><xsl:value-of select="//attribute[@name='eppn']/@value"/></username>
                             <fullname><xsl:value-of select="//attribute[@name='displayedName']/@value"/></fullname>
                             <familyName><xsl:value-of select="//attribute[@name='sn']/@value"/></familyName>
                             <givenName><xsl:value-of select="//attribute[@name='givenName']/@value"/></givenName>
@@ -33,16 +33,16 @@
                     </xsl:otherwise>
                 </xsl:choose>
             </xsl:when>
-            <!--  Institutions that use CAS for Authentication  -->
+            <!--  Institutions that use the CAS protocol for Authentication  -->
             <xsl:when test="$delegation-protocol = 'cas-pac4j'">
                 <xsl:variable name="idp" select="//attribute[@name='Cas-Identity-Provider']/@value" />
                 <idp><xsl:value-of select="$idp"/></idp>
                 <xsl:choose>
-                    <!--  Example CAS University  -->
+                    <!--  Example CAS-auth University  -->
                     <xsl:when test="$idp='ecu'">
                         <id>ecu</id>
                         <user>
-                            <!--  Each institution has customized mapping of attributes  -->
+                            <!--  Each institution has its customized mapping of attributes  -->
                             <username><xsl:value-of select="//attribute[@name='mail']/@value"/></username>
                             <fullname><xsl:value-of select="//attribute[@name='displayedName']/@value"/></fullname>
                             <familyName><xsl:value-of select="//attribute[@name='sn']/@value"/></familyName>

--- a/etc/institutions-auth.xsl
+++ b/etc/institutions-auth.xsl
@@ -27,6 +27,18 @@
                             <suffix/>
                         </user>
                     </xsl:when>
+                    <!-- University of North Carolina at Chapel Hill (UNC) -->
+                    <xsl:when test="$idp='urn:mace:incommon:unc.edu'">
+                        <id>unc</id>
+                        <user>
+                            <username><xsl:value-of select="//attribute[@name='eppn']/@value"/></username>
+                            <fullname><xsl:value-of select="//attribute[@name='displayName']/@value"/></fullname>
+                            <familyName><xsl:value-of select="//attribute[@name='sn']/@value"/></familyName>
+                            <givenName><xsl:value-of select="//attribute[@name='givenName']/@value"/></givenName>
+                            <middleNames/>
+                            <suffix/>
+                        </user>
+                    </xsl:when>
                     <!--  Unknown Identity Provider  -->
                     <xsl:otherwise>
                         <xsl:message terminate="yes">Error: Unknown Identity Provider '<xsl:value-of select="$idp"/>'</xsl:message>


### PR DESCRIPTION
## Ticket

[ENG-866](https://openscience.atlassian.net/browse/ENG-866)

## Purpose

Update `institutions-auth.xsl` for UNC

Here is the complementary [OSF-PR#9139](https://github.com/CenterForOpenScience/osf.io/pull/9139)

## Changes

### Primary

* Added UNC to `institutions-auth.xsl`

### By-product(s)

* Improved `institutions-auth.xsl`
* Slipped in another trivial update for PR templates

## Dev / QA Notes

This change only affects local development.

## DevOps Notes

This change only affects local development.
