### PR TITLE
[No Ticket] [OSF Institutions] Update OSF Institution SSO via CAS

### DIFF
--- a/docs/osf-institutions-sso-via-cas.md
+++ b/docs/osf-institutions-sso-via-cas.md
@@ -1,0 +1,38 @@
+# Connecting to the Open Science Framework (OSF) via CAS-based Single Sign-On (SSO)
+
+COS's CAS-based SSO has limited functionality since it is just an alternative for institutions that can not use the Shibboleth-based SSO. Before proceeding, please read [Connecting to the Open Science Framework (OSF) via Shibboleth-based Single Sign-On (SSO)](https://github.com/CenterForOpenScience/cas-overlay/blob/develop/docs/osf-institutions-sso-via-saml.md) first for non-technical information on connecting to OSF via SSO.
+
+## Technical Implementation
+
+This SSO is based on [`cas-4.1.x`](https://github.com/apereo/cas/tree/4.1.x) and [`pac4j-1.7.x`](https://github.com/pac4j/pac4j/tree/1.7.x). Please refer to the [CAS protocol](https://apereo.github.io/cas/4.1.x/protocol/CAS-Protocol.html) and the [complete specification](https://apereo.github.io/cas/4.1.x/protocol/CAS-Protocol-Specification.html) for how CAS works.
+
+When connecting to the OSF via CAS-based SSO, COS's CAS system (OSF CAS) acts as the **CAS Client** and your institution's CAS system acts as the **CAS Server**. To implement and test SSO for your institution, please follow the steps below.
+
+### Registered Service
+
+Add OSF CAS domain / URL to your CAS system's **Registered Service** list and allow wildcard matching for query parameters.
+
+* Production: `https://accounts.osf.io/login?`
+* Test / Staging: `https://accounts.test.osf.io/login?`
+
+### Authentication Endpoints
+
+Inform COS of the domain of your CAS system. More specifically, OSF CAS (as a client) expects the following endpoints to be available and functional.
+
+* Login: `<your CAS system domain>/login`
+* Logout: `<your CAS system domain>/logout`
+* Validation and attribute release: `<your CAS system domain>/samlValidate`
+
+### Service Validation and Attribute Release
+
+OSF CAS makes a `POST` request to your CAS system's [`/samlValidate`](https://apereo.github.io/cas/4.1.x/protocol/CAS-Protocol-Specification.html#42-samlvalidate-cas-30) endpoint for ticket validation and attribute release. Please release the following required attributes and inform us of the attribute name for each.
+
+* Unique identifier for the user (e.g. `eppn`)
+* User's institutional email (e.g. `mail`)
+* User's full name (e.g. `displayName`)
+
+Please note that OSF CAS can not use your [`/p3/serviceValidate`](https://apereo.github.io/cas/4.1.x/protocol/CAS-Protocol-Specification.html#28-p3servicevalidate-cas-30) endpoint due to an old version of the library it uses, namely [`pac4j-1.7.x`](https://github.com/pac4j/pac4j/tree/1.7.x) and [`cas-server-support-pac4j-1.7.x`](https://github.com/apereo/cas/tree/4.1.x/cas-server-support-pac4j). In addition, OSF CAS does not use your [`/validate`](https://apereo.github.io/cas/4.1.x/protocol/CAS-Protocol-Specification.html#24-validate-cas-10) and [`/serviceValidate`](https://apereo.github.io/cas/4.1.x/protocol/CAS-Protocol-Specification.html#25-servicevalidate-cas-20) endpoints since these two can not release required attributes.
+
+### Test Accounts
+
+It is highly recommended that you can create a temporary institution test account for COS engineers (if possible), which will significantly aid and accelerate the process.

--- a/docs/osf-institutions-sso-via-saml.md
+++ b/docs/osf-institutions-sso-via-saml.md
@@ -25,7 +25,7 @@ COS is an [Research & Scholarship Entity Category (R&S)](https://refeds.org/cate
 * Entity ID: `https://accounts.osf.io/shibboleth`
 * Requested Attributes: `eduPersonPrincipalName` (SAML2), `mail` (SAML2) and `displayName` (SAML2)
 
-The full technical details can be found at https://www.incommon.org/federation/research-scholarship-adopters/.
+Full technical details can be found at https://www.incommon.org/federation/research-scholarship-adopters/.
 
 Please note that only COS's production SP is registered by InCommon. If you want to connect to COS's test / staging SP, here is the [SP metadata](https://accounts.test.osf.io/Shibboleth.sso/Metadata) as mentioned in **Other Institutions** below.
 
@@ -46,3 +46,10 @@ COS offers a Service Provider (SP) based on [SAML 2.0](https://docs.oasis-open.o
 ### For All Institutions
 
 Inform COS of the user you would like to test with; your COS contact will ensure your account is ready to go and will send you a link to test the SSO configuration setup for your institution.
+
+
+## Alternative SSO Options
+
+COS strongly recommends using this Shibboleth-based SSO when connecting to the OSF. However, if this is not available at your institution, please inform COS of alternative SSO options you have. We may support them in the future.
+
+One alternative that COS currently supports is the CAS-based SSO, please refer to [Connecting to the Open Science Framework (OSF) via CAS-based Single Sign-On (SSO)](https://github.com/CenterForOpenScience/cas-overlay/blob/develop/docs/osf-institutions-sso-via-cas.md) for technical details.


### PR DESCRIPTION
## Ticket

N/A

## Purpose

Add a guide for integrate institution login via the CAS protocol, which is an alternative to institutions that does not implement a SAML 2.0 IdP. This PR does not deserve a ticket and should've been included in the ticket [ENG-913](https://openscience.atlassian.net/browse/ENG-913) and its PR https://github.com/CenterForOpenScience/cas-overlay/pull/155.

## Changes

* Added CAS-based SSO guide
* Updated Shibboleth-based SSO guide

## Dev / QA Notes

N/A

## Dev-Ops Notes

N/A

