### PR TITLE
[ENG-887] [OSF Institutions] Update `institutions-auth.xsl` for UBC

### DIFF
--- a/etc/institutions-auth.xsl
+++ b/etc/institutions-auth.xsl
@@ -56,6 +56,18 @@
                             <suffix/>
                         </user>
                     </xsl:when>
+                    <!-- University of British Columbia [Test] (UBC) -->
+                    <xsl:when test="$idp='https://authentication.stg.id.ubc.ca'">
+                        <id>ubc</id>
+                        <user>
+                            <username><xsl:value-of select="//attribute[@name='mail']/@value"/></username>
+                            <fullname><xsl:value-of select="//attribute[@name='displayName']/@value"/></fullname>
+                            <familyName/>
+                            <givenName/>
+                            <middleNames/>
+                            <suffix/>
+                        </user>
+                    </xsl:when>
                     <!-- University of North Carolina at Chapel Hill (UNC) -->
                     <xsl:when test="$idp='urn:mace:incommon:unc.edu'">
                         <id>unc</id>

--- a/etc/institutions-auth.xsl
+++ b/etc/institutions-auth.xsl
@@ -56,6 +56,18 @@
                             <suffix/>
                         </user>
                     </xsl:when>
+                    <!-- University of British Columbia (UBC) -->
+                    <xsl:when test="$idp='https://authentication.ubc.ca'">
+                        <id>ubc</id>
+                        <user>
+                            <username><xsl:value-of select="//attribute[@name='mail']/@value"/></username>
+                            <fullname><xsl:value-of select="//attribute[@name='displayName']/@value"/></fullname>
+                            <familyName/>
+                            <givenName/>
+                            <middleNames/>
+                            <suffix/>
+                        </user>
+                    </xsl:when>
                     <!-- University of British Columbia [Test] (UBC) -->
                     <xsl:when test="$idp='https://authentication.stg.id.ubc.ca'">
                         <id>ubc</id>


### PR DESCRIPTION
## Ticket

[ENG-887](https://openscience.atlassian.net/browse/ENG-887)

## Purpose

Update `institutions-auth.xsl` for UBC

Here is the complementary [OSF-PR#9143](https://github.com/CenterForOpenScience/osf.io/pull/9143) for UBC Test and [OSF-PR#9231](https://github.com/CenterForOpenScience/osf.io/pull/9231) for UBC Prod.

## Changes

- Add UBC Test and Prod to `institutions-auth.xsl`

## Dev / QA Notes

This change only affects local development.

## DevOps Notes

This change only affects local development.
