### PR TITLE
[No Ticket] Enable TODO comments

### DIFF
--- a/checkstyle-rules.xml
+++ b/checkstyle-rules.xml
@@ -225,7 +225,7 @@ Checkstyle configuration based on Sun's conventions, compliant with CAS coding c
       <property name="validateEnhancedForLoopVariable" value="true" />
     </module>
     <module name="TodoComment">
-      <property name="severity" value="error"/>
+      <property name="severity" value="warning"/>
     </module>
     <module name="MutableException">
       <property name="severity" value="error"/>


### PR DESCRIPTION
## Ticket

N / A

## Purpose

Lower the severity level from `error` to `warning` for TODO comments in style check so that we can enjoy both leaving TODO comments and keeping track of them.

## Changes

Lower the severity level from `error` to `warning` for TODO comments in style check.

## Dev / QA Notes

N / A

## Dev-Ops Notes

N / A

