### PR TITLE
[No Ticket] Fix ORCiD Login for Local Development and Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,10 +64,11 @@ The implementation of OSF CAS is based on [Yale/Jasig/Apereo CAS 4.1.x](https://
     # start jetty
     mvn -pl cas-server-webapp/ jetty:run
     ```
+* With default settings, CAS runs on port `8080` at IP address `192.168.168.167` locally. Change `server.name` here in [`cas.properties`](https://github.com/CenterForOpenScience/cas-overlay/blob/develop/etc/cas.properties#L117) if you want a different IP or port.
 
 ### A Few Extra Notes
 
-* To use the "Sign in with ORCiD" feature, create an application at [ORCiD Developer Tools](https://orcid.org/developer-tools). Update `oauth.orcid.client.id` and `oauth.orcid.client.secret` in the [`cas.properties`](https://github.com/CenterForOpenScience/cas-overlay/blob/develop/etc/cas.properties#L68).
+* To use the "Sign in with ORCiD" feature, create an application at [ORCiD Developer Tools](https://orcid.org/developer-tools) with **Redirect URI** set as `http://192.168.168.167:8080/login`. Alternatively, COS developers can use the credentials provided in https://osf.io/m2hig/wiki/home/. Update `oauth.orcid.client.id` and `oauth.orcid.client.secret` accordingly here in the [`cas.properties`](https://github.com/CenterForOpenScience/cas-overlay/blob/develop/etc/cas.properties#L68). ORCiD login will not work if CAS is run on a different `server.name` without updating 1) OSF `docker-compose` settings and 2) the **Redirect URI** of the ORCiD developer application.
 
 * The "Sign in through institution" feature is not available for local development. It requires a Shibboleth server sitting in front of CAS handling both SAML 2.0 authentication and TLS.
 

--- a/etc/cas.properties
+++ b/etc/cas.properties
@@ -114,7 +114,7 @@ oauth.loginUrl=${server.name}/login
 #### This section "Central Authentication Service (CAS)" contains default properties from jasig/apereo.
 ####
 
-server.name=http://localhost:8080
+server.name=http://192.168.168.167:8080
 server.prefix=${server.name}
 
 # Spring Security's EL-based access rules for the /status URI of CAS that exposes health check information


### PR DESCRIPTION
## Ticket

N / A

## Purpose

ORCiD login turns out to be broken with `localhost:8080` as the CAS `server.name`. I have been using a domain with TLS locally and never tested the non-TLS default CAS settings for local development. This PR fix the issue.

## Changes

* Changed `server.name` from `http://localhost:8080` to `http://192.168.168.167:8080`.
* Updated README
- [x] @mattclark Please update the **Redirect URI** by adding `http://192.168.168.167:8080/login` for the ORCiD developer application specified in [here](https://osf.io/m2hig/wiki/home/). Without this change, developers need to create their own application.

## Dev / QA Notes

Dev QA

## Dev-Ops Notes

N / A
