### PR TITLE
[ENG-1049] Gracefully Handle ORCiD Login Exceptions

### DIFF
--- a/cas-server-support-osf/src/main/java/io/cos/cas/authentication/exceptions/CasClientLoginException.java
+++ b/cas-server-support-osf/src/main/java/io/cos/cas/authentication/exceptions/CasClientLoginException.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to Apereo under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work
+ * for additional information regarding copyright ownership.
+ * Apereo licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License.  You may obtain a
+ * copy of the License at the following location:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package io.cos.cas.authentication.exceptions;
+
+/**
+ * The CAS Client Login Exception.
+ *
+ * This is the special login exception class for authentication failures during delegated client login via
+ * {@link org.jasig.cas.support.pac4j.web.flow.ClientAction} and {@link org.pac4j.cas.client.CasClient}.
+ *
+ * @author Longze Chen
+ * @since 4.1.5
+ */
+public class CasClientLoginException extends DelegatedLoginException {
+
+    /** Unique id for serialization. */
+    private static final long serialVersionUID = -7180107167551919266L;
+
+    /**
+     * Instantiate a new {@link CasClientLoginException} with no detail message.
+     */
+    public CasClientLoginException() {
+        super();
+    }
+
+    /**
+     * Instantiate a new {@link CasClientLoginException} with the specified detail message.
+     *
+     * @param msg the detail message
+     */
+    public CasClientLoginException(final String msg) {
+        super(msg);
+    }
+}

--- a/cas-server-support-osf/src/main/java/io/cos/cas/authentication/exceptions/DelegatedLoginException.java
+++ b/cas-server-support-osf/src/main/java/io/cos/cas/authentication/exceptions/DelegatedLoginException.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to Apereo under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work
+ * for additional information regarding copyright ownership.
+ * Apereo licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License.  You may obtain a
+ * copy of the License at the following location:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package io.cos.cas.authentication.exceptions;
+
+import javax.security.auth.login.FailedLoginException;
+
+/**
+ * The Delegated Login Exception.
+ *
+ * This is a generic login exception for authentication via delegated client.
+ *
+ * @author Longze Chen
+ * @since 4.1.5
+ */
+public class DelegatedLoginException extends FailedLoginException {
+
+    /** Unique id for serialization. */
+    private static final long serialVersionUID = 2120800337731452548L;
+
+    /**
+     * Instantiate a new {@link DelegatedLoginException} with no detail message.
+     */
+    public DelegatedLoginException() {
+        super();
+    }
+
+    /**
+     * Instantiate a new {@link DelegatedLoginException} with the specified detail message.
+     *
+     * @param msg the detail message
+     */
+    public DelegatedLoginException(final String msg) {
+        super(msg);
+    }
+}

--- a/cas-server-support-osf/src/main/java/io/cos/cas/authentication/exceptions/OrcidClientLoginException.java
+++ b/cas-server-support-osf/src/main/java/io/cos/cas/authentication/exceptions/OrcidClientLoginException.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to Apereo under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work
+ * for additional information regarding copyright ownership.
+ * Apereo licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License.  You may obtain a
+ * copy of the License at the following location:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package io.cos.cas.authentication.exceptions;
+
+/**
+ * The ORCiD Client Login Exception.
+ *
+ * This is the special login exception class for authentication failures during delegated client login via
+ * {@link org.jasig.cas.support.pac4j.web.flow.ClientAction} and {@link org.pac4j.oauth.client.OrcidClient}.
+ *
+ * @author Longze Chen
+ * @since 4.1.5
+ */
+public class OrcidClientLoginException extends DelegatedLoginException {
+
+    /** Unique id for serialization. */
+    private static final long serialVersionUID = 2120800337731452548L;
+
+    /**
+     * Instantiate a new {@link OrcidClientLoginException} with no detail message.
+     */
+    public OrcidClientLoginException() {
+        super();
+    }
+
+    /**
+     * Instantiate a new {@link OrcidClientLoginException} with the specified detail message.
+     *
+     * @param msg the detail message
+     */
+    public OrcidClientLoginException(final String msg) {
+        super(msg);
+    }
+}

--- a/cas-server-support-osf/src/main/java/io/cos/cas/web/flow/OpenScienceFrameworkAuthenticationExceptionHandler.java
+++ b/cas-server-support-osf/src/main/java/io/cos/cas/web/flow/OpenScienceFrameworkAuthenticationExceptionHandler.java
@@ -23,6 +23,9 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import io.cos.cas.authentication.exceptions.CasClientLoginException;
+import io.cos.cas.authentication.exceptions.DelegatedLoginException;
+import io.cos.cas.authentication.exceptions.OrcidClientLoginException;
 import io.cos.cas.authentication.InvalidVerificationKeyException;
 import io.cos.cas.authentication.LoginNotAllowedException;
 import io.cos.cas.authentication.OneTimePasswordFailedLoginException;
@@ -85,6 +88,13 @@ public class OpenScienceFrameworkAuthenticationExceptionHandler extends Authenti
         DEFAULT_ERROR_LIST.add(RemoteUserFailedLoginException.class);
         DEFAULT_ERROR_LIST.add(OneTimePasswordFailedLoginException.class);
         DEFAULT_ERROR_LIST.add(OneTimePasswordRequiredException.class);
+    }
+
+    // Customized exceptions for delegated login
+    static {
+        DEFAULT_ERROR_LIST.add(DelegatedLoginException.class);
+        DEFAULT_ERROR_LIST.add(OrcidClientLoginException.class);
+        DEFAULT_ERROR_LIST.add(CasClientLoginException.class);
     }
 
     // Exceptions that should count against the login rate limiting

--- a/cas-server-support-osf/src/main/java/org/jasig/cas/support/pac4j/authentication/handler/support/AbstractClientAuthenticationHandler.java
+++ b/cas-server-support-osf/src/main/java/org/jasig/cas/support/pac4j/authentication/handler/support/AbstractClientAuthenticationHandler.java
@@ -25,82 +25,97 @@ import org.jasig.cas.authentication.handler.support.AbstractPreAndPostProcessing
 import org.jasig.cas.authentication.principal.DefaultPrincipalFactory;
 import org.jasig.cas.authentication.principal.PrincipalFactory;
 import org.jasig.cas.support.pac4j.authentication.principal.ClientCredential;
+
 import org.pac4j.core.client.Client;
 import org.pac4j.core.client.Clients;
 import org.pac4j.core.context.J2EContext;
 import org.pac4j.core.context.WebContext;
 import org.pac4j.core.credentials.Credentials;
 import org.pac4j.core.profile.UserProfile;
+
 import org.springframework.webflow.context.ExternalContextHolder;
 import org.springframework.webflow.context.servlet.ServletExternalContext;
+
+import java.security.GeneralSecurityException;
 
 import javax.security.auth.login.FailedLoginException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.validation.constraints.NotNull;
-import java.security.GeneralSecurityException;
 
 /**
- * Generic handler for delegated authentication: it uses the client credentials to get the user profile
- * returned by the provider for an authenticated user.
+ * The Abstract Client Authentication Handler.
+ *
+ * This class is a generic handler for authentication delegated to an auth client, implementing the authentication
+ * method {@link AbstractPreAndPostProcessingAuthenticationHandler#doAuthentication(Credential)}. It uses the auth
+ * client and provides it with client credentials in order to get the user profile returned by the provider for an
+ * authenticated user.
  *
  * @author Jerome Leleu
- * @since 4.1.0
+ * @author Longze Chen
+ * @since 4.1.5
  */
 @SuppressWarnings("unchecked")
 public abstract class AbstractClientAuthenticationHandler extends AbstractPreAndPostProcessingAuthenticationHandler {
 
-    /** Factory to create the principal type. **/
+    /** The factory to create the principal type. **/
     @NotNull
     protected PrincipalFactory principalFactory = new DefaultPrincipalFactory();
 
-    /**
-     * The clients for authentication.
-     */
+    /** The clients for authentication. */
     @NotNull
     private final Clients clients;
 
     /**
-     * Define the clients.
+     * Instantiate a new {@link AbstractClientAuthenticationHandler} and define the clients.
      *
-     * @param theClients The clients for authentication
+     * @param theClients the clients for authentication
      */
     public AbstractClientAuthenticationHandler(final Clients theClients) {
         this.clients = theClients;
     }
 
+    /**
+     * {@inheritDoc}
+     **/
     @Override
     public final boolean supports(final Credential credential) {
         return credential != null && ClientCredential.class.isAssignableFrom(credential.getClass());
     }
 
+    /**
+     * {@inheritDoc}
+     **/
     @Override
-    protected HandlerResult doAuthentication(final Credential credential) throws GeneralSecurityException, PreventedException {
+    protected HandlerResult doAuthentication(
+            final Credential credential
+    ) throws GeneralSecurityException, PreventedException {
+
+        // Construct a specific client credential from a general credential
         final ClientCredential clientCredentials = (ClientCredential) credential;
         logger.debug("clientCredentials : {}", clientCredentials);
 
+        // Retrieve the client by the client name found in the client credential
         final Credentials credentials = clientCredentials.getCredentials();
         final String clientName = credentials.getClientName();
         logger.debug("clientName : {}", clientName);
-
-        // get client
         final Client<Credentials, UserProfile> client = this.clients.findClient(clientName);
         logger.debug("client : {}", client);
 
-        // web context
-        final ServletExternalContext servletExternalContext = (ServletExternalContext) ExternalContextHolder.getExternalContext();
+        // Create the web context
+        final ServletExternalContext servletExternalContext
+                = (ServletExternalContext) ExternalContextHolder.getExternalContext();
         final HttpServletRequest request = (HttpServletRequest) servletExternalContext.getNativeRequest();
         final HttpServletResponse response = (HttpServletResponse) servletExternalContext.getNativeResponse();
         final WebContext webContext = new J2EContext(request, response);
 
-        // get user profile
+        // Retrieve user profile. If successful, create and return a handler result
         final UserProfile userProfile = client.getUserProfile(credentials, webContext);
         logger.debug("userProfile : {}", userProfile);
-
         if (userProfile != null) {
             return createResult(clientCredentials, userProfile);
         }
-
+        // Otherwise, throw an exception.
         throw new FailedLoginException("Provider did not produce a user profile for: " + clientCredentials);
     }
 
@@ -110,12 +125,19 @@ public abstract class AbstractClientAuthenticationHandler extends AbstractPreAnd
      * @param credentials the provided credentials
      * @param profile the retrieved user profile
      * @return the built handler result
-     * @throws GeneralSecurityException On authentication failure.
-     * @throws PreventedException On the indeterminate case when authentication is prevented.
+     * @throws GeneralSecurityException on authentication failure
+     * @throws PreventedException on the indeterminate case when authentication is prevented
      */
-    protected abstract HandlerResult createResult(final ClientCredential credentials, final UserProfile profile)
-            throws GeneralSecurityException, PreventedException;
+    protected abstract HandlerResult createResult(
+            final ClientCredential credentials,
+            final UserProfile profile
+    ) throws GeneralSecurityException, PreventedException;
 
+    /**
+     * Set the principal factory.
+     *
+     * @param principalFactory the principal factory
+     */
     public void setPrincipalFactory(final PrincipalFactory principalFactory) {
         this.principalFactory = principalFactory;
     }

--- a/cas-server-support-osf/src/main/java/org/jasig/cas/support/pac4j/authentication/handler/support/AbstractClientAuthenticationHandler.java
+++ b/cas-server-support-osf/src/main/java/org/jasig/cas/support/pac4j/authentication/handler/support/AbstractClientAuthenticationHandler.java
@@ -105,6 +105,7 @@ public abstract class AbstractClientAuthenticationHandler extends AbstractPreAnd
             client = this.clients.findClient(clientName);
             logger.debug("client : {}", client);
         } catch (final TechnicalException e) {
+            logger.error("Invalid client: {}", clientName);
             throw new DelegatedLoginException("Invalid client: " + clientName);
         }
 
@@ -121,6 +122,7 @@ public abstract class AbstractClientAuthenticationHandler extends AbstractPreAnd
             userProfile = client.getUserProfile(credentials, webContext);
             logger.debug("userProfile : {}", userProfile);
         } catch (final TechnicalException e) {
+            logger.error("Failed to retrieve user profile: client = {}, error = {}", clientName, e.getMessage());
             throw new DelegatedLoginException(e.getMessage());
         }
 
@@ -128,6 +130,7 @@ public abstract class AbstractClientAuthenticationHandler extends AbstractPreAnd
         if (userProfile != null) {
             return createResult(clientCredentials, userProfile);
         }
+        logger.error("Provider did not produce a user profile: client = {}", clientName);
         throw new DelegatedLoginException("Provider did not produce a user profile for: " + clientCredentials);
     }
 

--- a/cas-server-support-osf/src/main/java/org/jasig/cas/support/pac4j/authentication/handler/support/AbstractClientAuthenticationHandler.java
+++ b/cas-server-support-osf/src/main/java/org/jasig/cas/support/pac4j/authentication/handler/support/AbstractClientAuthenticationHandler.java
@@ -1,0 +1,122 @@
+/*
+ * Licensed to Apereo under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work
+ * for additional information regarding copyright ownership.
+ * Apereo licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License.  You may obtain a
+ * copy of the License at the following location:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.jasig.cas.support.pac4j.authentication.handler.support;
+
+import org.jasig.cas.authentication.Credential;
+import org.jasig.cas.authentication.HandlerResult;
+import org.jasig.cas.authentication.PreventedException;
+import org.jasig.cas.authentication.handler.support.AbstractPreAndPostProcessingAuthenticationHandler;
+import org.jasig.cas.authentication.principal.DefaultPrincipalFactory;
+import org.jasig.cas.authentication.principal.PrincipalFactory;
+import org.jasig.cas.support.pac4j.authentication.principal.ClientCredential;
+import org.pac4j.core.client.Client;
+import org.pac4j.core.client.Clients;
+import org.pac4j.core.context.J2EContext;
+import org.pac4j.core.context.WebContext;
+import org.pac4j.core.credentials.Credentials;
+import org.pac4j.core.profile.UserProfile;
+import org.springframework.webflow.context.ExternalContextHolder;
+import org.springframework.webflow.context.servlet.ServletExternalContext;
+
+import javax.security.auth.login.FailedLoginException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.validation.constraints.NotNull;
+import java.security.GeneralSecurityException;
+
+/**
+ * Generic handler for delegated authentication: it uses the client credentials to get the user profile
+ * returned by the provider for an authenticated user.
+ *
+ * @author Jerome Leleu
+ * @since 4.1.0
+ */
+@SuppressWarnings("unchecked")
+public abstract class AbstractClientAuthenticationHandler extends AbstractPreAndPostProcessingAuthenticationHandler {
+
+    /** Factory to create the principal type. **/
+    @NotNull
+    protected PrincipalFactory principalFactory = new DefaultPrincipalFactory();
+
+    /**
+     * The clients for authentication.
+     */
+    @NotNull
+    private final Clients clients;
+
+    /**
+     * Define the clients.
+     *
+     * @param theClients The clients for authentication
+     */
+    public AbstractClientAuthenticationHandler(final Clients theClients) {
+        this.clients = theClients;
+    }
+
+    @Override
+    public final boolean supports(final Credential credential) {
+        return credential != null && ClientCredential.class.isAssignableFrom(credential.getClass());
+    }
+
+    @Override
+    protected HandlerResult doAuthentication(final Credential credential) throws GeneralSecurityException, PreventedException {
+        final ClientCredential clientCredentials = (ClientCredential) credential;
+        logger.debug("clientCredentials : {}", clientCredentials);
+
+        final Credentials credentials = clientCredentials.getCredentials();
+        final String clientName = credentials.getClientName();
+        logger.debug("clientName : {}", clientName);
+
+        // get client
+        final Client<Credentials, UserProfile> client = this.clients.findClient(clientName);
+        logger.debug("client : {}", client);
+
+        // web context
+        final ServletExternalContext servletExternalContext = (ServletExternalContext) ExternalContextHolder.getExternalContext();
+        final HttpServletRequest request = (HttpServletRequest) servletExternalContext.getNativeRequest();
+        final HttpServletResponse response = (HttpServletResponse) servletExternalContext.getNativeResponse();
+        final WebContext webContext = new J2EContext(request, response);
+
+        // get user profile
+        final UserProfile userProfile = client.getUserProfile(credentials, webContext);
+        logger.debug("userProfile : {}", userProfile);
+
+        if (userProfile != null) {
+            return createResult(clientCredentials, userProfile);
+        }
+
+        throw new FailedLoginException("Provider did not produce a user profile for: " + clientCredentials);
+    }
+
+    /**
+     * Build the handler result.
+     *
+     * @param credentials the provided credentials
+     * @param profile the retrieved user profile
+     * @return the built handler result
+     * @throws GeneralSecurityException On authentication failure.
+     * @throws PreventedException On the indeterminate case when authentication is prevented.
+     */
+    protected abstract HandlerResult createResult(final ClientCredential credentials, final UserProfile profile)
+            throws GeneralSecurityException, PreventedException;
+
+    public void setPrincipalFactory(final PrincipalFactory principalFactory) {
+        this.principalFactory = principalFactory;
+    }
+}

--- a/cas-server-support-osf/src/main/java/org/jasig/cas/support/pac4j/authentication/handler/support/AbstractClientAuthenticationHandler.java
+++ b/cas-server-support-osf/src/main/java/org/jasig/cas/support/pac4j/authentication/handler/support/AbstractClientAuthenticationHandler.java
@@ -18,9 +18,7 @@
  */
 package org.jasig.cas.support.pac4j.authentication.handler.support;
 
-import io.cos.cas.authentication.exceptions.CasClientLoginException;
 import io.cos.cas.authentication.exceptions.DelegatedLoginException;
-import io.cos.cas.authentication.exceptions.OrcidClientLoginException;
 
 import org.jasig.cas.authentication.Credential;
 import org.jasig.cas.authentication.HandlerResult;
@@ -29,7 +27,6 @@ import org.jasig.cas.authentication.principal.DefaultPrincipalFactory;
 import org.jasig.cas.authentication.principal.PrincipalFactory;
 import org.jasig.cas.support.pac4j.authentication.principal.ClientCredential;
 
-import org.pac4j.cas.client.CasClient;
 import org.pac4j.core.client.Client;
 import org.pac4j.core.client.Clients;
 import org.pac4j.core.context.J2EContext;
@@ -37,7 +34,6 @@ import org.pac4j.core.context.WebContext;
 import org.pac4j.core.credentials.Credentials;
 import org.pac4j.core.exception.TechnicalException;
 import org.pac4j.core.profile.UserProfile;
-import org.pac4j.oauth.client.OrcidClient;
 
 import org.springframework.webflow.context.ExternalContextHolder;
 import org.springframework.webflow.context.servlet.ServletExternalContext;
@@ -119,17 +115,12 @@ public abstract class AbstractClientAuthenticationHandler extends AbstractPreAnd
         final HttpServletResponse response = (HttpServletResponse) servletExternalContext.getNativeResponse();
         final WebContext webContext = new J2EContext(request, response);
 
-        // Retrieve the user profile
+        // Attempt to retrieve the user profile
         final UserProfile userProfile;
         try {
             userProfile = client.getUserProfile(credentials, webContext);
             logger.debug("userProfile : {}", userProfile);
         } catch (final TechnicalException e) {
-            if (OrcidClient.class.getSimpleName().equals(client.getName())) {
-                throw new OrcidClientLoginException(e.getMessage());
-            } else if (CasClient.class.getSimpleName().equals(client.getName())) {
-                throw new CasClientLoginException(e.getMessage());
-            }
             throw new DelegatedLoginException(e.getMessage());
         }
 

--- a/cas-server-support-osf/src/main/java/org/jasig/cas/support/pac4j/authentication/handler/support/ClientAuthenticationHandler.java
+++ b/cas-server-support-osf/src/main/java/org/jasig/cas/support/pac4j/authentication/handler/support/ClientAuthenticationHandler.java
@@ -74,9 +74,11 @@ public class ClientAuthenticationHandler extends AbstractClientAuthenticationHan
                         new BasicCredentialMetaData(credentials),
                         this.principalFactory.createPrincipal(id, profile.getAttributes()));
             } catch (final Exception e) {
+                logger.error("Failed to create handler result for profile: id = {}, error = {}", id, e.getMessage());
                 throw new DelegatedLoginException(e.getMessage());
             }
         }
+        logger.error("No identifier found for user profile");
         throw new DelegatedLoginException("No identifier found for this user profile: " + profile);
     }
 

--- a/cas-server-support-osf/src/main/java/org/jasig/cas/support/pac4j/authentication/handler/support/ClientAuthenticationHandler.java
+++ b/cas-server-support-osf/src/main/java/org/jasig/cas/support/pac4j/authentication/handler/support/ClientAuthenticationHandler.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to Apereo under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work
+ * for additional information regarding copyright ownership.
+ * Apereo licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License.  You may obtain a
+ * copy of the License at the following location:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.jasig.cas.support.pac4j.authentication.handler.support;
+
+import org.apache.commons.lang3.StringUtils;
+import org.jasig.cas.authentication.BasicCredentialMetaData;
+import org.jasig.cas.authentication.DefaultHandlerResult;
+import org.jasig.cas.authentication.HandlerResult;
+import org.jasig.cas.authentication.PreventedException;
+import org.jasig.cas.support.pac4j.authentication.principal.ClientCredential;
+import org.pac4j.core.client.Clients;
+import org.pac4j.core.profile.UserProfile;
+
+import javax.security.auth.login.FailedLoginException;
+import java.security.GeneralSecurityException;
+
+/**
+ * Specialized handler which builds the authenticated user directly from the retrieved user profile.
+ *
+ * @author Jerome Leleu
+ * @since 3.5.0
+ */
+public class ClientAuthenticationHandler extends AbstractClientAuthenticationHandler {
+
+    /**
+     * Whether to use the typed identifier (by default) or just the identifier.
+     */
+    private boolean typedIdUsed = true;
+
+    /**
+     * Define the clients.
+     *
+     * @param theClients The clients for authentication
+     */
+    public ClientAuthenticationHandler(final Clients theClients) {
+        super(theClients);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    protected HandlerResult createResult(final ClientCredential credentials, final UserProfile profile)
+            throws GeneralSecurityException, PreventedException {
+        final String id;
+        if (typedIdUsed) {
+            id = profile.getTypedId();
+        } else {
+            id = profile.getId();
+        }
+        if (StringUtils.isNotBlank(id)) {
+            credentials.setUserProfile(profile);
+            credentials.setTypedIdUsed(typedIdUsed);
+            return new DefaultHandlerResult(
+                    this,
+                    new BasicCredentialMetaData(credentials),
+                    this.principalFactory.createPrincipal(id, profile.getAttributes()));
+        }
+        throw new FailedLoginException("No identifier found for this user profile: " + profile);
+    }
+
+    public boolean isTypedIdUsed() {
+        return typedIdUsed;
+    }
+
+    public void setTypedIdUsed(final boolean typedIdUsed) {
+        this.typedIdUsed = typedIdUsed;
+    }
+}

--- a/cas-server-support-osf/src/main/java/org/jasig/cas/support/pac4j/authentication/handler/support/ClientAuthenticationHandler.java
+++ b/cas-server-support-osf/src/main/java/org/jasig/cas/support/pac4j/authentication/handler/support/ClientAuthenticationHandler.java
@@ -19,34 +19,38 @@
 package org.jasig.cas.support.pac4j.authentication.handler.support;
 
 import org.apache.commons.lang3.StringUtils;
+
 import org.jasig.cas.authentication.BasicCredentialMetaData;
 import org.jasig.cas.authentication.DefaultHandlerResult;
 import org.jasig.cas.authentication.HandlerResult;
 import org.jasig.cas.authentication.PreventedException;
 import org.jasig.cas.support.pac4j.authentication.principal.ClientCredential;
+
 import org.pac4j.core.client.Clients;
 import org.pac4j.core.profile.UserProfile;
 
-import javax.security.auth.login.FailedLoginException;
 import java.security.GeneralSecurityException;
 
+import javax.security.auth.login.FailedLoginException;
+
 /**
- * Specialized handler which builds the authenticated user directly from the retrieved user profile.
+ * The Client Authentication Handler.
+ *
+ * This class is a specialized handler which builds the authenticated user directly from the retrieved user profile.
  *
  * @author Jerome Leleu
- * @since 3.5.0
+ * @author Longze Chen
+ * @since 4.1.5
  */
 public class ClientAuthenticationHandler extends AbstractClientAuthenticationHandler {
 
-    /**
-     * Whether to use the typed identifier (by default) or just the identifier.
-     */
+    /** Whether to use the typed identifier (default) or just the identifier. */
     private boolean typedIdUsed = true;
 
     /**
-     * Define the clients.
+     * Instantiate a new {@link ClientAuthenticationHandler} and define the clients.
      *
-     * @param theClients The clients for authentication
+     * @param theClients the clients for authentication
      */
     public ClientAuthenticationHandler(final Clients theClients) {
         super(theClients);
@@ -56,14 +60,12 @@ public class ClientAuthenticationHandler extends AbstractClientAuthenticationHan
      * {@inheritDoc}
      */
     @Override
-    protected HandlerResult createResult(final ClientCredential credentials, final UserProfile profile)
-            throws GeneralSecurityException, PreventedException {
-        final String id;
-        if (typedIdUsed) {
-            id = profile.getTypedId();
-        } else {
-            id = profile.getId();
-        }
+    protected HandlerResult createResult(
+            final ClientCredential credentials,
+            final UserProfile profile
+    ) throws GeneralSecurityException, PreventedException {
+
+        final String id = typedIdUsed ? profile.getTypedId() : profile.getId();
         if (StringUtils.isNotBlank(id)) {
             credentials.setUserProfile(profile);
             credentials.setTypedIdUsed(typedIdUsed);
@@ -75,10 +77,20 @@ public class ClientAuthenticationHandler extends AbstractClientAuthenticationHan
         throw new FailedLoginException("No identifier found for this user profile: " + profile);
     }
 
+    /**
+     * Check if type ID is used.
+     *
+     * @return the type ID flag
+     */
     public boolean isTypedIdUsed() {
         return typedIdUsed;
     }
 
+    /**
+     * Toggle the type ID flag on and off.
+     *
+     * @param typedIdUsed a boolean value to set the type ID flag
+     */
     public void setTypedIdUsed(final boolean typedIdUsed) {
         this.typedIdUsed = typedIdUsed;
     }

--- a/cas-server-support-osf/src/main/java/org/jasig/cas/support/pac4j/web/flow/ClientAction.java
+++ b/cas-server-support-osf/src/main/java/org/jasig/cas/support/pac4j/web/flow/ClientAction.java
@@ -1,0 +1,245 @@
+/*
+ * Licensed to Apereo under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work
+ * for additional information regarding copyright ownership.
+ * Apereo licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License.  You may obtain a
+ * copy of the License at the following location:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.jasig.cas.support.pac4j.web.flow;
+
+import java.util.Set;
+
+import com.google.common.collect.ImmutableSet;
+import org.apache.commons.lang3.StringUtils;
+import org.jasig.cas.CentralAuthenticationService;
+import org.jasig.cas.authentication.principal.Service;
+import org.jasig.cas.authentication.principal.WebApplicationService;
+import org.jasig.cas.support.pac4j.authentication.principal.ClientCredential;
+import org.jasig.cas.ticket.TicketGrantingTicket;
+import org.jasig.cas.web.support.WebUtils;
+import org.pac4j.core.client.BaseClient;
+import org.pac4j.core.client.Client;
+import org.pac4j.core.client.Clients;
+import org.pac4j.core.client.Mechanism;
+import org.pac4j.core.context.J2EContext;
+import org.pac4j.core.context.WebContext;
+import org.pac4j.core.credentials.Credentials;
+import org.pac4j.core.exception.RequiresHttpAction;
+import org.pac4j.core.exception.TechnicalException;
+import org.pac4j.core.profile.CommonProfile;
+import org.pac4j.core.profile.ProfileHelper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.webflow.action.AbstractAction;
+import org.springframework.webflow.context.ExternalContext;
+import org.springframework.webflow.context.ExternalContextHolder;
+import org.springframework.webflow.execution.Event;
+import org.springframework.webflow.execution.RequestContext;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
+import javax.validation.constraints.NotNull;
+
+/**
+ * This class represents an action to put at the beginning of the webflow.
+ * <p>
+ * Before any authentication, redirection urls are computed for the different clients defined as well as the theme,
+ * locale, method and service are saved into the web session.</p>
+ * After authentication, appropriate information are expected on this callback url to finish the authentication
+ * process with the provider.
+ * @author Jerome Leleu
+ * @since 3.5.0
+ */
+@SuppressWarnings({ "unchecked", "rawtypes" })
+public final class ClientAction extends AbstractAction {
+    /**
+     * Constant for the service parameter.
+     */
+    public static final String SERVICE = "service";
+    /**
+     * Constant for the theme parameter.
+     */
+    public static final String THEME = "theme";
+    /**
+     * Constant for the locale parameter.
+     */
+    public static final String LOCALE = "locale";
+    /**
+     * Constant for the method parameter.
+     */
+    public static final String METHOD = "method";
+    /**
+     * Supported protocols.
+     */
+    private static final Set<Mechanism> SUPPORTED_PROTOCOLS = ImmutableSet.of(Mechanism.CAS_PROTOCOL, Mechanism.OAUTH_PROTOCOL,
+            Mechanism.OPENID_PROTOCOL, Mechanism.SAML_PROTOCOL, Mechanism.OPENID_CONNECT_PROTOCOL);
+
+    /**
+     * The logger.
+     */
+    private final Logger logger = LoggerFactory.getLogger(ClientAction.class);
+
+    /**
+     * The clients used for authentication.
+     */
+    @NotNull
+    private final Clients clients;
+
+    /**
+     * The service for CAS authentication.
+     */
+    @NotNull
+    private final CentralAuthenticationService centralAuthenticationService;
+
+    /**
+     * Build the action.
+     *
+     * @param theCentralAuthenticationService The service for CAS authentication
+     * @param theClients The clients for authentication
+     */
+    public ClientAction(final CentralAuthenticationService theCentralAuthenticationService,
+                        final Clients theClients) {
+        this.centralAuthenticationService = theCentralAuthenticationService;
+        this.clients = theClients;
+        ProfileHelper.setKeepRawData(true);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    protected Event doExecute(final RequestContext context) throws Exception {
+        final HttpServletRequest request = WebUtils.getHttpServletRequest(context);
+        final HttpServletResponse response = WebUtils.getHttpServletResponse(context);
+        final HttpSession session = request.getSession();
+
+        // web context
+        final WebContext webContext = new J2EContext(request, response);
+
+        // get client
+        final String clientName = request.getParameter(this.clients.getClientNameParameter());
+        logger.debug("clientName: {}", clientName);
+
+        // it's an authentication
+        if (StringUtils.isNotBlank(clientName)) {
+            // get client
+            final BaseClient<Credentials, CommonProfile> client =
+                    (BaseClient<Credentials, CommonProfile>) this.clients
+                            .findClient(clientName);
+            logger.debug("client: {}", client);
+
+            // Only supported protocols
+            final Mechanism mechanism = client.getMechanism();
+            if (!SUPPORTED_PROTOCOLS.contains(mechanism)) {
+                throw new TechnicalException("Only CAS, OAuth, OpenID and SAML protocols are supported: " + client);
+            }
+
+            // get credentials
+            final Credentials credentials;
+            try {
+                credentials = client.getCredentials(webContext);
+                logger.debug("credentials: {}", credentials);
+            } catch (final RequiresHttpAction e) {
+                logger.debug("requires http action: {}", e);
+                response.flushBuffer();
+                final ExternalContext externalContext = ExternalContextHolder.getExternalContext();
+                externalContext.recordResponseComplete();
+                return new Event(this, "stop");
+            }
+
+            // retrieve parameters from web session
+            final Service service = (Service) session.getAttribute(SERVICE);
+            context.getFlowScope().put(SERVICE, service);
+            logger.debug("retrieve service: {}", service);
+            if (service != null) {
+                request.setAttribute(SERVICE, service.getId());
+            }
+            restoreRequestAttribute(request, session, THEME);
+            restoreRequestAttribute(request, session, LOCALE);
+            restoreRequestAttribute(request, session, METHOD);
+
+            // credentials not null -> try to authenticate
+            if (credentials != null) {
+                final TicketGrantingTicket tgt =
+                        this.centralAuthenticationService.createTicketGrantingTicket(new ClientCredential(credentials));
+                WebUtils.putTicketGrantingTicketInScopes(context, tgt);
+                return success();
+            }
+        }
+
+        // no or aborted authentication : go to login page
+        prepareForLoginPage(context);
+        return error();
+    }
+
+    /**
+     * Prepare the data for the login page.
+     *
+     * @param context The current webflow context
+     */
+    protected void prepareForLoginPage(final RequestContext context) {
+        final HttpServletRequest request = WebUtils.getHttpServletRequest(context);
+        final HttpServletResponse response = WebUtils.getHttpServletResponse(context);
+        final HttpSession session = request.getSession();
+
+        // web context
+        final WebContext webContext = new J2EContext(request, response);
+
+        // save parameters in web session
+        final WebApplicationService service = WebUtils.getService(context);
+        logger.debug("save service: {}", service);
+        session.setAttribute(SERVICE, service);
+        saveRequestParameter(request, session, THEME);
+        saveRequestParameter(request, session, LOCALE);
+        saveRequestParameter(request, session, METHOD);
+
+        // for all clients, generate redirection urls
+        for (final Client client : this.clients.findAllClients()) {
+            final String key = client.getName() + "Url";
+            final BaseClient baseClient = (BaseClient) client;
+            final String redirectionUrl = baseClient.getRedirectionUrl(webContext);
+            logger.debug("{} -> {}", key, redirectionUrl);
+            context.getFlowScope().put(key, redirectionUrl);
+        }
+    }
+
+    /**
+     * Restore an attribute in web session as an attribute in request.
+     *
+     * @param request The HTTP request
+     * @param session The HTTP session
+     * @param name The name of the parameter
+     */
+    private void restoreRequestAttribute(final HttpServletRequest request, final HttpSession session,
+                                         final String name) {
+        final String value = (String) session.getAttribute(name);
+        request.setAttribute(name, value);
+    }
+
+    /**
+     * Save a request parameter in the web session.
+     *
+     * @param request The HTTP request
+     * @param session The HTTP session
+     * @param name The name of the parameter
+     */
+    private void saveRequestParameter(final HttpServletRequest request, final HttpSession session,
+                                      final String name) {
+        final String value = request.getParameter(name);
+        if (value != null) {
+            session.setAttribute(name, value);
+        }
+    }
+}

--- a/cas-server-support-osf/src/main/java/org/pac4j/oauth/client/OrcidClient.java
+++ b/cas-server-support-osf/src/main/java/org/pac4j/oauth/client/OrcidClient.java
@@ -221,7 +221,8 @@ public class OrcidClient extends BaseOAuth20Client<OrcidProfile> {
      *
      * This method overrides {@link BaseOAuthClient#sendRequestForData(Token, String)}. Here are the customizations:
      *
-     * 1. Removed access token from requests since the public API doesn't require it.
+     * 1. No longer appends the access token as a query parameter to the URL.
+     * 2. Always includes the access token using the "Authorization" header.
      * 3. Improved the way how log messages are built.
      * 4. Use interface constants {@link HttpStatus#SC_OK} instead of number literals.
      *
@@ -239,6 +240,9 @@ public class OrcidClient extends BaseOAuth20Client<OrcidProfile> {
         logger.debug("accessToken : {} / dataUrl : {}", accessToken, dataUrl);
         final long t0 = System.currentTimeMillis();
         final ProxyOAuthRequest request = createProxyRequest(dataUrl);
+        if (accessToken != null) {
+            request.addHeader("Authorization", "Bearer " + accessToken.getToken());
+        }
         final Response response = request.send();
         final int code = response.getCode();
         final String body = response.getBody();

--- a/cas-server-support-osf/src/main/java/org/pac4j/oauth/client/OrcidClient.java
+++ b/cas-server-support-osf/src/main/java/org/pac4j/oauth/client/OrcidClient.java
@@ -32,8 +32,8 @@ import org.scribe.model.ProxyOAuthRequest;
 import org.scribe.model.Response;
 import org.scribe.model.SignatureType;
 import org.scribe.model.Token;
-import org.scribe.tokens.OrcidToken;
 import org.scribe.oauth.ProxyOAuth20ServiceImpl;
+import org.scribe.tokens.OrcidToken;
 
 /**
  * The ORCiD Client.
@@ -47,7 +47,18 @@ import org.scribe.oauth.ProxyOAuth20ServiceImpl;
  */
 public class OrcidClient extends BaseOAuth20Client<OrcidProfile> {
 
-    /** The default scope. */
+    /**
+     * The default scope.
+     *
+     * OSF CAS uses the "/authenticate" scope for the purpose of authentication only. According to ORCiD API docs, this
+     * scope is used when the client system will collect the ORCID iD but does not need access to read-limited data or
+     * will use the ORCID system as an authentication provider. This scope is available on the Member or Public API.
+     * For more information about ORCiD scopes, refer to https://members.orcid.org/api/oauth/orcid-scopes.
+     *
+     * In addition, "pac4j" version of the ORCiD OAuth 2.0 client implementation must use the 3-legged OAuth and the
+     * "/authenticate" scope is such a 3-legged scope. For more information on 2-legged and 3-legged OAuth, refer to
+     * https://members.orcid.org/api/oauth/2legged-oauth and https://members.orcid.org/api/oauth/3legged-oauth.
+     */
     protected static final String DEFAULT_SCOPE = "/authenticate";
 
     /** The scope. */

--- a/cas-server-support-osf/src/main/java/org/pac4j/oauth/client/OrcidClient.java
+++ b/cas-server-support-osf/src/main/java/org/pac4j/oauth/client/OrcidClient.java
@@ -48,7 +48,7 @@ import org.scribe.oauth.ProxyOAuth20ServiceImpl;
 public class OrcidClient extends BaseOAuth20Client<OrcidProfile> {
 
     /** The default scope. */
-    protected static final String DEFAULT_SCOPE = "/orcid-profile/read-limited";
+    protected static final String DEFAULT_SCOPE = "/authenticate";
 
     /** The scope. */
     protected String scope = DEFAULT_SCOPE;

--- a/cas-server-support-osf/src/main/java/org/scribe/builder/api/OrcidApi20.java
+++ b/cas-server-support-osf/src/main/java/org/scribe/builder/api/OrcidApi20.java
@@ -32,7 +32,7 @@ import org.scribe.utils.OAuthEncoder;
 public class OrcidApi20 extends DefaultApi20 {
 
     /** The authorization url. */
-    private static final String AUTH_URL = "https://www.orcid.org/oauth/authorize";
+    private static final String AUTH_URL = "https://orcid.org/oauth/authorize";
 
     /** The token exchange url. */
     private static final String TOKEN_URL = "https://orcid.org/oauth/token";

--- a/cas-server-webapp/src/main/resources/messages.properties
+++ b/cas-server-webapp/src/main/resources/messages.properties
@@ -100,6 +100,23 @@ authenticationFailure.FailedLoginException=The email or password you entered is 
 authenticationFailure.OneTimePasswordRequiredException=
 authenticationFailure.OneTimePasswordFailedLoginException=The passcode you entered is incorrect.
 authenticationFailure.UNKNOWN=Invalid credentials.
+# Delegated login failure messages
+screen.delegatedloginfailure.generic.header=Delegated Authentication Error
+screen.delegatedloginfailure.generic.message=We can not complete your request at this time due to an unexpected error \
+  during delegated login. Please <a style="white-space: nowrap" href="{0}">go back to the OSF</a> and try again later. \
+  If the issue persists, please contact <a style="white-space: nowrap" href="mailto:support@osf.io">OSF Support</a> \
+  for help.
+screen.delegatedloginfailure.cas.header=Institution Login Error
+screen.delegatedloginfailure.cas.message=We can not complete your request at this time due to an unexpected error \
+  during institution login. Please <a style="white-space: nowrap" href="{0}">go back to the OSF</a> and try again \
+  later.</br></br>If the issue persists, please check with your institution first to verify that your account is \
+  entitled to authenticate to OSF.</br></br>If you believe this should not happen, please contact \
+  <a style="white-space: nowrap" href="mailto:support@osf.io">OSF Support</a> for help.
+screen.delegatedloginfailure.orcid.header=ORCiD Login Error
+screen.delegatedloginfailure.orcid.message=We can not complete your request at this time due to an unexpected error \
+  during ORCiD login. Please <a style="white-space: nowrap" href="{0}">go back to the OSF</a> and try again later. If \
+  the issue persists, please contact <a style="white-space: nowrap" href="mailto:support@osf.io">OSF Support</a> for \
+  help.
 
 INVALID_REQUEST_PROXY='pgt' and 'targetService' parameters are both required
 INVALID_TICKET_SPEC=Ticket failed validation specification.  Possible errors could include attempting to validate a Proxy Ticket via a Service Ticket validator, or not complying with the renew true request.
@@ -166,7 +183,7 @@ screen.institution.login.select.error.message=You must select an institution.
 
 # Sign in through OSF
 screen.osf.login.message=Sign in with your OSF account to continue
-screen.osf.login.message.error=Oops! Something went wrong
+screen.osf.login.message.error=Oops! Something went wrong ...
 
 # Two-factor Authentication
 screen.2fa.login.heading=Two-factor authentication

--- a/cas-server-webapp/src/main/webapp/WEB-INF/view/jsp/default/ui/delegatedLoginCasErrorView.jsp
+++ b/cas-server-webapp/src/main/webapp/WEB-INF/view/jsp/default/ui/delegatedLoginCasErrorView.jsp
@@ -19,7 +19,7 @@
 
 --%>
 
-<%-- Login exception page: invalid or unexpected user status --%>
+<%-- Delegated login exception page: CAS client --%>
 
 <jsp:directive.include file="includes/top.jsp"/>
 

--- a/cas-server-webapp/src/main/webapp/WEB-INF/view/jsp/default/ui/delegatedLoginCasErrorView.jsp
+++ b/cas-server-webapp/src/main/webapp/WEB-INF/view/jsp/default/ui/delegatedLoginCasErrorView.jsp
@@ -1,0 +1,44 @@
+<%--
+
+    Licensed to Apereo under one or more contributor license
+    agreements. See the NOTICE file distributed with this work
+    for additional information regarding copyright ownership.
+    Apereo licenses this file to you under the Apache License,
+    Version 2.0 (the "License"); you may not use this file
+    except in compliance with the License.  You may obtain a
+    copy of the License at the following location:
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+--%>
+
+<%-- Login exception page: invalid or unexpected user status --%>
+
+<jsp:directive.include file="includes/top.jsp"/>
+
+<spring:message code="screen.osf.login.message.error" var="errorDescription"/>
+<script>
+    description = document.getElementById("description");
+    if (description != null) {
+        description.innerHTML = "<br><br>${errorDescription}";
+    }
+</script>
+
+<div id="msg" class="errors">
+    <h2><spring:message code="screen.delegatedloginfailure.cas.header"/></h2>
+    <p><spring:message code="screen.delegatedloginfailure.cas.message" arguments="${osfUrl}"/></p>
+</div>
+
+<c:set var="linkSignIn" value="false"/>
+<c:set var="linkSignOut" value="false"/>
+<c:set var="linkCreateAccount" value="false"/>
+<c:set var="linkBackToOsf" value="false"/>
+
+<jsp:directive.include file="includes/bottom.jsp"/>

--- a/cas-server-webapp/src/main/webapp/WEB-INF/view/jsp/default/ui/delegatedLoginGenericErrorView.jsp
+++ b/cas-server-webapp/src/main/webapp/WEB-INF/view/jsp/default/ui/delegatedLoginGenericErrorView.jsp
@@ -19,7 +19,7 @@
 
 --%>
 
-<%-- Login exception page: invalid or unexpected user status --%>
+<%-- Generic delegated login exception page --%>
 
 <jsp:directive.include file="includes/top.jsp"/>
 

--- a/cas-server-webapp/src/main/webapp/WEB-INF/view/jsp/default/ui/delegatedLoginGenericErrorView.jsp
+++ b/cas-server-webapp/src/main/webapp/WEB-INF/view/jsp/default/ui/delegatedLoginGenericErrorView.jsp
@@ -1,0 +1,44 @@
+<%--
+
+    Licensed to Apereo under one or more contributor license
+    agreements. See the NOTICE file distributed with this work
+    for additional information regarding copyright ownership.
+    Apereo licenses this file to you under the Apache License,
+    Version 2.0 (the "License"); you may not use this file
+    except in compliance with the License.  You may obtain a
+    copy of the License at the following location:
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+--%>
+
+<%-- Login exception page: invalid or unexpected user status --%>
+
+<jsp:directive.include file="includes/top.jsp"/>
+
+<spring:message code="screen.osf.login.message.error" var="errorDescription"/>
+<script>
+    description = document.getElementById("description");
+    if (description != null) {
+        description.innerHTML = "<br><br>${errorDescription}";
+    }
+</script>
+
+<div id="msg" class="errors">
+    <h2><spring:message code="screen.delegatedloginfailure.generic.header"/></h2>
+    <p><spring:message code="screen.delegatedloginfailure.generic.message" arguments="${osfUrl}"/></p>
+</div>
+
+<c:set var="linkSignIn" value="false"/>
+<c:set var="linkSignOut" value="false"/>
+<c:set var="linkCreateAccount" value="false"/>
+<c:set var="linkBackToOsf" value="false"/>
+
+<jsp:directive.include file="includes/bottom.jsp"/>

--- a/cas-server-webapp/src/main/webapp/WEB-INF/view/jsp/default/ui/delegatedLoginOrcidErrorView.jsp
+++ b/cas-server-webapp/src/main/webapp/WEB-INF/view/jsp/default/ui/delegatedLoginOrcidErrorView.jsp
@@ -19,7 +19,7 @@
 
 --%>
 
-<%-- Login exception page: invalid or unexpected user status --%>
+<%-- Delegated login exception page: ORCiD client --%>
 
 <jsp:directive.include file="includes/top.jsp"/>
 

--- a/cas-server-webapp/src/main/webapp/WEB-INF/view/jsp/default/ui/delegatedLoginOrcidErrorView.jsp
+++ b/cas-server-webapp/src/main/webapp/WEB-INF/view/jsp/default/ui/delegatedLoginOrcidErrorView.jsp
@@ -1,0 +1,44 @@
+<%--
+
+    Licensed to Apereo under one or more contributor license
+    agreements. See the NOTICE file distributed with this work
+    for additional information regarding copyright ownership.
+    Apereo licenses this file to you under the Apache License,
+    Version 2.0 (the "License"); you may not use this file
+    except in compliance with the License.  You may obtain a
+    copy of the License at the following location:
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+--%>
+
+<%-- Login exception page: invalid or unexpected user status --%>
+
+<jsp:directive.include file="includes/top.jsp"/>
+
+<spring:message code="screen.osf.login.message.error" var="errorDescription"/>
+<script>
+    description = document.getElementById("description");
+    if (description != null) {
+        description.innerHTML = "<br><br>${errorDescription}";
+    }
+</script>
+
+<div id="msg" class="errors">
+    <h2><spring:message code="screen.delegatedloginfailure.orcid.header"/></h2>
+    <p><spring:message code="screen.delegatedloginfailure.orcid.message" arguments="${osfUrl}"/></p>
+</div>
+
+<c:set var="linkSignIn" value="false"/>
+<c:set var="linkSignOut" value="false"/>
+<c:set var="linkCreateAccount" value="false"/>
+<c:set var="linkBackToOsf" value="false"/>
+
+<jsp:directive.include file="includes/bottom.jsp"/>

--- a/cas-server-webapp/src/main/webapp/WEB-INF/webflow/login/login-webflow.xml
+++ b/cas-server-webapp/src/main/webapp/WEB-INF/webflow/login/login-webflow.xml
@@ -35,6 +35,7 @@
         <transition on="success" to="remoteAuthenticate" />
         <transition on="error" to="ticketGrantingTicketCheck" />
         <transition on="stop" to="stopWebflow" />
+        <transition on="authenticationFailure" to="handleAuthenticationFailure" />
     </action-state>
     <view-state id="stopWebflow" />
 

--- a/cas-server-webapp/src/main/webapp/WEB-INF/webflow/login/login-webflow.xml
+++ b/cas-server-webapp/src/main/webapp/WEB-INF/webflow/login/login-webflow.xml
@@ -207,6 +207,10 @@
         <transition on="RemoteUserFailedLoginException" to="casRemoteUserFailedLoginView" />
         <transition on="OneTimePasswordRequiredException" to="casOtpLoginView"/>
         <transition on="OneTimePasswordFailedLoginException" to="casOtpLoginView"/>
+        <!-- Customized exceptions for delegated login -->
+        <transition on="DelegatedLoginException" to="delegatedLoginGenericErrorView" />
+        <transition on="CasClientLoginException" to="delegatedLoginCasErrorView"/>
+        <transition on="OrcidClientLoginException" to="delegatedLoginOrcidErrorView"/>
         <!-- Unhandled Exceptions -->
         <transition on="UNKNOWN" to="generateLoginTicket"/>
     </action-state>
@@ -280,6 +284,9 @@
     <end-state id="casShouldNotHappenView" view="casShouldNotHappenView" />
     <end-state id="casRemoteUserFailedLoginView" view="casRemoteUserFailedLoginView" />
     <end-state id="casInvalidVerificationKeyView" view="casInvalidVerificationKeyView" />
+    <end-state id="delegatedLoginGenericErrorView" view="delegatedLoginGenericErrorView" />
+    <end-state id="delegatedLoginCasErrorView" view="delegatedLoginCasErrorView" />
+    <end-state id="delegatedLoginOrcidErrorView" view="delegatedLoginOrcidErrorView" />
 
     <end-state id="postView" view="postResponseView">
         <on-entry>


### PR DESCRIPTION
## Ticket

https://openscience.atlassian.net/browse/ENG-1049

## Purpose

Whenever something went wrong in `pac4j` (a library we use), it crashes CAS. This PR  fixes this issue by rewiring the login web flow so that CAS can handle exceptions from ORCiD login (and other delegated login including CAS) gracefully.

## Changes

### Major Change

* New exceptions for delegated login failures
* New views (pages) for the new exceptions
* The auth handlers throw the generic delegated login exception
* The client action throws the client specific delegated login exception
* The client action catches the exceptions (including ones thrown by itself) and returns a new event that redirects the login web flow to the main CAS auth exception handler.
* The main exception handler makes takes care of the rest and redirect users to the new exception pages accordingly

### Minor Tweaks

* Use access token (via `Authorization` header instead of query parameter) when making ORCiD public API calls.
* Replaced deprecated default scope with `/authenticate`. This has no effect since the default scope will be overwritten by custom server config, which happens to be `/authenticate` anyway.
* Revoked prefix "www." from the authorize url.
* Refactored the code style for overlayed classes touched in this PR so that functionality changes are in their own commits and more readable.

### Side Effect

Handles exceptions for all `pac4j`-delegated login gracefully, including institution login via the `CasClient`.

## Dev / QA Notes

* Dev Regression Test

### New Exception Pages

It is very hard to trigger errors (e.g. network issue, permission denied, etc.) during delegated login. Here is how to manually trigger the error to see the new pages.

* ORCiD Client failure due to invalid or expired authorization code:

	https://accounts.staging.osf.io/login?client_name=OrcidClient&code=INVALID_OR_EXPIRED_CODE&service=https%3A%2F%2Fstaging.osf.io%2Flogin%2F%3Fnext%3Dhttps%253A%252F%252Fstaging.osf.io%252F

* CAS Client failure due to invalid or expired service ticket:

	https://accounts.staging.osf.io/login?client_name=callutheran&ticket=INVALID_OR_EXPIRED_TICKET&service=https%3A%2F%2Fstaging.osf.io%2Flogin%2F%3Fnext%3Dhttps%253A%252F%252Fstaging.osf.io%252F

* General authentication delegation failures. For example, invalid client:

	https://accounts.staging.osf.io/login?client_name=INVALID_CLIENT_NAME&service=https%3A%2F%2Fstaging.osf.io%2Flogin%2F%3Fnext%3Dhttps%253A%252F%252Fstaging.osf.io%252F
## Dev-Ops Notes

No

