### PR TITLE
[No Ticket] [OSF Institutions] Update Login Endpoint for Callutheran

### DIFF
--- a/etc/cas.properties
+++ b/etc/cas.properties
@@ -56,7 +56,7 @@ delegation.redirect.uri=${server.name}/login
 # Authentication Delegation: Clients
 #
 # CAS Client: California Lutheran University
-cas.callutheran.login.url=https://sso.callutheran.edu/cas/login
+cas.callutheran.login.url=https://login.callutheran.edu/cas/login
 cas.callutheran.client.name=callutheran
 cas.callutheran.cas.protocol=SAML
 #


### PR DESCRIPTION
## Ticket

N / A

## Purpose

Callutheran has changed their SSO provider. As far as OSF CAS is concerned, it is just the login endpoint update from `https://sso.callutheran.edu/` to `https://login.callutheran.edu/`. More specifically, the new login URL will be `https://login.callutheran.edu/cas/login` and the new validation URL (calculated from the above login URL by `pac4j`) will be `https://login.callutheran.edu/cas/samlValidate`.

## Changes

See **Section Purpose**

## Dev / QA Notes

Post-release QA will be done by the institution.

## Dev-Ops Notes

@cslzchen 

- [x] PR can be merged at any time since the change only affects local development. In addition, please deny the `prod` deployment.

@mfraezz 

- [ ] For both `test` and `prod` CAS settings, update `cas.callutheran.login.url` to be `https://login.callutheran.edu/cas/login` for `cas.properties`.

- [ ] ~~Need to coordinate the release with the institution.~~ Their old system is still alive after new one is up. So need to to coordinate; just after the new one goes alive.