### PR TITLE
[ENG-1110] [OSF Institutions] Manually Set the CAS Prefix URL for PAC4J CAS Clients

### DIFF
--- a/cas-server-webapp/src/main/webapp/WEB-INF/spring-configuration/authenticationDelegation.xml
+++ b/cas-server-webapp/src/main/webapp/WEB-INF/spring-configuration/authenticationDelegation.xml
@@ -39,12 +39,14 @@ under the License.
     <!-- Oklahoma State University -->
     <bean id="okstate" class="org.pac4j.cas.client.CasClient">
         <property name="casLoginUrl" value="${cas.okstate.login.url}" />
+        <property name="casPrefixUrl" value="${cas.okstate.prefix.url}" />
         <property name="name" value="${cas.okstate.client.name}" />
         <property name="casProtocol" value="${cas.okstate.cas.protocol}" />
     </bean>
     <!-- California Lutheran University -->
     <bean id="callutheran" class="org.pac4j.cas.client.CasClient">
         <property name="casLoginUrl" value="${cas.callutheran.login.url}" />
+        <property name="casPrefixUrl" value="${cas.callutheran.prefix.url}" />
         <property name="name" value="${cas.callutheran.client.name}" />
         <property name="casProtocol" value="${cas.callutheran.cas.protocol}" />
     </bean>

--- a/etc/cas.properties
+++ b/etc/cas.properties
@@ -57,11 +57,13 @@ delegation.redirect.uri=${server.name}/login
 #
 # CAS Client: California Lutheran University
 cas.callutheran.login.url=https://login.callutheran.edu/cas/login
+cas.callutheran.prefix.url=https://login.callutheran.edu/cas/
 cas.callutheran.client.name=callutheran
 cas.callutheran.cas.protocol=SAML
 #
 # CAS Client: Oklahoma State University
-cas.okstate.login.url=https://stgcas.okstate.edu/cas/login
+cas.okstate.login.url=https://stwcas.okstate.edu/cas/login
+cas.okstate.prefix.url=https://stwcas.okstate.edu/cas/
 cas.okstate.client.name=okstate
 cas.okstate.cas.protocol=SAML
 #


### PR DESCRIPTION
## Ticket

https://openscience.atlassian.net/browse/ENG-1110

## Purpose

There happen to be a bug in `pac4j-1.7.x` CAS clients where the prefix URL calculated from the login URL may be wrong / invalid if the login URL contains multiple `/login` substrings. By manually setting the prefix URL during bean/class init, the above bugged calculation never happens.

This bug was discovered during testing https://github.com/CenterForOpenScience/cas-overlay/pull/165.

### More About the Bug

When the login URL is:

```
https://sso.callutheran.edu/cas/login
```

it is correctly turned into the prefix URL:

```
https://sso.callutheran.edu/cas/
```
by replacing THE FIRST `/login` with `/` and then appended with the URL suffix `samlValidate`.

However, this fails for the new endpoint

```
https://login.callutheran.edu/cas/login
```

since the prefix URL becomes

```
https://.callutheran.edu/cas/login/
```

A few references:
* [CAS Client](https://github.com/pac4j/pac4j/blob/1.7.x/pac4j-cas/src/main/java/org/pac4j/cas/client/CasClient.java#L156)
* [SAML Ticket Validator](https://github.com/apereo/java-cas-client/blob/3.5.x/cas-client-support-saml/src/main/java/org/jasig/cas/client/validation/Saml11TicketValidator.java#L109-L110)
* [Abstract URL Based Ticket Validator](https://github.com/apereo/java-cas-client/blob/3.5.x/cas-client-core/src/main/java/org/jasig/cas/client/validation/AbstractUrlBasedTicketValidator.java#L120-L127)

## Changes

* Update Spring config so the CAS clients are initialized with the correct prefix URL
* Add `cas.callutheran.prefix.url` and `cas.okstate.prefix.url` to cas.properties

### Side Effects

* Update `cas.okstate.login.url` to point to the production server.

## Dev / QA Notes

N / A

## Dev-Ops Notes

### Merge to `feature/master-test`

- [ ] Phase 1: please update `cas.properties` for the `test` server only by adding the following two lines:

  ```
  cas.callutheran.prefix.url=https://login.callutheran.edu/cas/
  ...
  cas.okstate.prefix.url=https://stgcas.okstate.edu/cas/
  ```

### Release to `master`

- [ ] Phase 2: please update `cas.properties` for `prod` and `staging-*` servers by adding the following two lines:

  * Production
  
  ```
  cas.callutheran.prefix.url=https://login.callutheran.edu/cas/
  ...
  cas.okstate.prefix.url=https://stwcas.okstate.edu/cas/
  ```

  * Stagings

  ```
  cas.callutheran.prefix.url=https://login.callutheran.edu/cas/
  ...
  cas.okstate.prefix.url=https://stgcas.okstate.edu/cas/
  ```
  
 Please note that CAS will fail to start if the settings are not ready.
