### PR TITLE
[ENG-1149] Update the OSF TOTP Model: `deleted` -> `is_deleted`

### DIFF
--- a/cas-server-support-osf/src/main/java/io/cos/cas/adaptors/postgres/models/OpenScienceFrameworkTimeBasedOneTimePassword.java
+++ b/cas-server-support-osf/src/main/java/io/cos/cas/adaptors/postgres/models/OpenScienceFrameworkTimeBasedOneTimePassword.java
@@ -54,7 +54,7 @@ public class OpenScienceFrameworkTimeBasedOneTimePassword {
     @Column(name = "is_confirmed", nullable = false)
     private Boolean confirmed;
 
-    @Column(name = "deleted", nullable = false)
+    @Column(name = "is_deleted", nullable = false)
     private Boolean deleted;
 
     /** Default Constructor. */


### PR DESCRIPTION
## Ticket

https://openscience.atlassian.net/browse/ENG-1149

## Purpose

OSF has [updated](https://github.com/CenterForOpenScience/osf.io/commit/f93add77f87ce46689be0a0f4d9c6e19f7f78bc2#diff-efa2839fe769cc45f3802492e55481d4R43-R44) the `deleted` field for the `BaseAddonSettings` model, which affects the `TwoFactorUserSettings` model that CAS relies on for two-factor authentication. More specifically, the `deleted` field became a `NonNaiveDateTimeField` and a new `is_deleted` replaces the old `deleted` as a `BooleanField`. CAS needs to be updated to understand the new model.

## Changes

CAS has been fixed temporarily in this ticket to use the `is_delelted` field until the new `deleted` has been fully populated.

## Dev / QA Notes

No. Please refer to the OSF-side ticket [ENG-821](https://openscience.atlassian.net/browse/ENG-821) and its [PR](https://github.com/CenterForOpenScience/osf.io/pull/9132) for testing notes.

## Dev-Ops Notes

- [ ] Must be released to `prod` at the same time with https://github.com/CenterForOpenScience/osf.io/pull/9132


