### PR TITLE
[No Ticket] [OSF Institutions] Update CALLUTHERAN and Fix the Prefix URL for PAC4J CAS Clients

### DIFF
--- a/cas-server-webapp/src/main/webapp/WEB-INF/spring-configuration/authenticationDelegation.xml
+++ b/cas-server-webapp/src/main/webapp/WEB-INF/spring-configuration/authenticationDelegation.xml
@@ -39,12 +39,14 @@ under the License.
     <!-- Oklahoma State University -->
     <bean id="okstate" class="org.pac4j.cas.client.CasClient">
         <property name="casLoginUrl" value="${cas.okstate.login.url}" />
+        <property name="casPrefixUrl" value="${cas.okstate.prefix.url}" />
         <property name="name" value="${cas.okstate.client.name}" />
         <property name="casProtocol" value="${cas.okstate.cas.protocol}" />
     </bean>
     <!-- California Lutheran University -->
     <bean id="callutheran" class="org.pac4j.cas.client.CasClient">
         <property name="casLoginUrl" value="${cas.callutheran.login.url}" />
+        <property name="casPrefixUrl" value="${cas.callutheran.prefix.url}" />
         <property name="name" value="${cas.callutheran.client.name}" />
         <property name="casProtocol" value="${cas.callutheran.cas.protocol}" />
     </bean>

--- a/etc/cas.properties
+++ b/etc/cas.properties
@@ -56,12 +56,14 @@ delegation.redirect.uri=${server.name}/login
 # Authentication Delegation: Clients
 #
 # CAS Client: California Lutheran University
-cas.callutheran.login.url=https://login.callutheran.edu/cas/login
+cas.callutheran.login.url=https://sso.callutheran.edu/cas/login
+cas.callutheran.prefix.url=https://sso.callutheran.edu/cas/
 cas.callutheran.client.name=callutheran
 cas.callutheran.cas.protocol=SAML
 #
 # CAS Client: Oklahoma State University
-cas.okstate.login.url=https://stgcas.okstate.edu/cas/login
+cas.okstate.login.url=https://stwcas.okstate.edu/cas/login
+cas.okstate.prefix.url=https://stwcas.okstate.edu/cas/
 cas.okstate.client.name=okstate
 cas.okstate.cas.protocol=SAML
 #

--- a/etc/institutions-auth.xsl
+++ b/etc/institutions-auth.xsl
@@ -27,6 +27,18 @@
                             <suffix/>
                         </user>
                     </xsl:when>
+                    <!-- California Lutheran University [SAML SSO] (CALLUTHERAN2)-->
+                    <xsl:when test="$idp='login.callutheran.edu'">
+                        <id>callutheran2</id>
+                        <user>
+                            <username><xsl:value-of select="//attribute[@name='mail']/@value"/></username>
+                            <fullname><xsl:value-of select="//attribute[@name='displayName']/@value"/></fullname>
+                            <familyName/>
+                            <givenName/>
+                            <middleNames/>
+                            <suffix/>
+                        </user>
+                    </xsl:when>
                     <!-- University of North Carolina at Chapel Hill (UNC) -->
                     <xsl:when test="$idp='urn:mace:incommon:unc.edu'">
                         <id>unc</id>
@@ -63,7 +75,7 @@
                             <suffix/>
                         </user>
                     </xsl:when>
-                    <!-- California Lutheran University (CALLUTHERAN)-->
+                    <!-- California Lutheran University [CAS SSO] (CALLUTHERAN)-->
                     <xsl:when test="$idp='callutheran'">
                         <id>callutheran</id>
                         <user>


### PR DESCRIPTION
## Ticket

No ticket but relates to: https://openscience.atlassian.net/browse/ENG-1110

## Purpose

Add California Lutheran University (CAS SSO).

## Changes

* Add `callutheran2` to `institutions-auth.xsl`.

### Extra

* Fix a potential bug in calculating the Prefix URL for `pac4j` CAS clients
* Update local settings to use `prod` Login / Prefix URL for `okstate`

## Dev / QA Notes

Dev QA

## Dev-Ops Notes

### CAS / Jetty

- [x] `test` Server: add the following config to the `saml-shib` section in `institutions-auth.xsl`

```xml
<!-- California Lutheran University [SAML SSO] (CALLUTHERAN2)-->
<xsl:when test="$idp='login.callutheran.edu'">
    <id>callutheran2</id>
    <user>
        <username><xsl:value-of select="//attribute[@name='mail']/@value"/></username>
        <fullname><xsl:value-of select="//attribute[@name='displayName']/@value"/></fullname>
        <familyName/>
        <givenName/>
        <middleNames/>
        <suffix/>
    </user>
</xsl:when>
```

- [x] `test` Server: double check the following is in the `cas-pac4j` section in `institutions-auth.xsl`.

```xml
<!-- California Lutheran University [CAS SSO] (CALLUTHERAN)-->
<xsl:when test="$idp='callutheran'">
    <id>callutheran</id>
    <user>
        <username><xsl:value-of select="//attribute[@name='email']/@value"/></username>
        <familyName><xsl:value-of select="//attribute[@name='familyName']/@value"/></familyName>
        <givenName><xsl:value-of select="//attribute[@name='givenName']/@value"/></givenName>
        <fullname/>
        <middleNames/>
        <suffix/>
    </user>
</xsl:when>
```

- [x]`test` AND `prod` Server: update helm charts and system environment according to `cas.properties` updates in this PR.

```bash
# CAS Client: California Lutheran University
cas.callutheran.login.url=https://sso.callutheran.edu/cas/login
cas.callutheran.prefix.url=https://sso.callutheran.edu/cas/
cas.callutheran.client.name=callutheran
cas.callutheran.cas.protocol=SAML
#
# CAS Client: Oklahoma State University
cas.okstate.login.url=https://stwcas.okstate.edu/cas/login
cas.okstate.prefix.url=https://stwcas.okstate.edu/cas/
cas.okstate.client.name=okstate
cas.okstate.cas.protocol=SAML
```

### Shibboleth / Apache

- [x] `test` Server : add the following config to `shibboleth2.xml`. Rename `backingFilePath` if necessary. `prod` Server should have the same update but it is optional for the scope of this PR.

```xml
<!-- California Lutheran University (CALLUTHERAN) -->
<MetadataProvider type="XML"
                  uri="https://login.callutheran.edu/sso/metadata.ashx"
                  backingFilePath="callutheran-test-idp-metadata.xml"
                  reloadInterval="180000" />
```
