### PR TITLE
[Supporting ENG-1448] Add Boys Town to `institutions-auth.xsl` for Attributes Normalization

### DIFF
--- a/etc/institutions-auth.xsl
+++ b/etc/institutions-auth.xsl
@@ -44,6 +44,19 @@
                             <suffix/>
                         </user>
                     </xsl:when>
+                    <!-- Boys Town [PROD & Test] (BT) -->
+                    <!-- Prod and Test IdP of Boys Town share the entity ID but the metadata itself is different. -->
+                    <xsl:when test="$idp='https://sts.windows.net/e2ab7419-36ab-4a95-a19f-ee90b6a9b8ac/'">
+                        <id>bt</id>
+                        <user>
+                            <username><xsl:value-of select="//attribute[@name='mail']/@value"/></username>
+                            <fullname><xsl:value-of select="//attribute[@name='displayName']/@value"/></fullname>
+                            <familyName><xsl:value-of select="//attribute[@name='sn']/@value"/></familyName>
+                            <givenName><xsl:value-of select="//attribute[@name='givenName']/@value"/></givenName>
+                            <middleNames/>
+                            <suffix/>
+                        </user>
+                    </xsl:when>
                     <!-- California Lutheran University [SAML SSO] (CALLUTHERAN)-->
                     <xsl:when test="$idp='login.callutheran.edu'">
                         <id>callutheran</id>


### PR DESCRIPTION
## Ticket

### Related Tickets and PRs

* Ticket: https://openscience.atlassian.net/browse/ENG-1448
* OSF PR: https://github.com/CenterForOpenScience/osf.io/pull/9281

## Purpose

Add Boys Town to `institutions-auth.xsl` for attributes normalization

## Changes

Please see the code diff.

## Dev / QA Notes

Dev QA is not available w/o an account. Institution verification is required.

## Dev-Ops Notes

This PR only affects local development. For server update, see https://github.com/CenterForOpenScience/osf.io/pull/9281
