### PR TITLE
[ENG-1205] Improve CAS Exceptions

### DIFF
--- a/cas-server-support-osf/src/main/java/io/cos/cas/adaptors/postgres/handlers/OpenScienceFrameworkAuthenticationHandler.java
+++ b/cas-server-support-osf/src/main/java/io/cos/cas/adaptors/postgres/handlers/OpenScienceFrameworkAuthenticationHandler.java
@@ -25,10 +25,10 @@ import io.cos.cas.adaptors.postgres.models.OpenScienceFrameworkUser;
 import io.cos.cas.authentication.exceptions.AccountNotConfirmedIdPLoginException;
 import io.cos.cas.authentication.exceptions.AccountNotConfirmedOsfLoginException;
 import io.cos.cas.authentication.exceptions.InvalidVerificationKeyException;
+import io.cos.cas.authentication.exceptions.InvalidUserStatusException;
 import io.cos.cas.authentication.exceptions.OneTimePasswordFailedLoginException;
 import io.cos.cas.authentication.exceptions.OneTimePasswordRequiredException;
 import io.cos.cas.authentication.OpenScienceFrameworkCredential;
-import io.cos.cas.authentication.exceptions.ShouldNotHappenException;
 import io.cos.cas.authentication.oath.TotpUtils;
 
 import org.jasig.cas.authentication.AccountDisabledException;
@@ -195,11 +195,11 @@ public class OpenScienceFrameworkAuthenticationHandler extends AbstractPreAndPos
         }  else if (USER_DISABLED.equals(userStatus)) {
             throw new AccountDisabledException(username + " is disabled");
         } else if (USER_NOT_CLAIMED.equals(userStatus)) {
-            throw new ShouldNotHappenException(username + " is not claimed");
+            throw new InvalidUserStatusException(username + " is not claimed");
         } else if (USER_MERGED.equals(userStatus)) {
-            throw new ShouldNotHappenException("Cannot log in to a merged user " + username);
+            throw new InvalidUserStatusException("Cannot log in to a merged user " + username);
         } else if (USER_STATUS_UNKNOWN.equals(userStatus)) {
-            throw new ShouldNotHappenException(username + " is not active: unknown status");
+            throw new InvalidUserStatusException(username + " is not active: unknown status");
         }
         final Map<String, Object> attributes = new HashMap<>();
         attributes.put("username", user.getUsername());
@@ -261,7 +261,7 @@ public class OpenScienceFrameworkAuthenticationHandler extends AbstractPreAndPos
                             logger.info("User Status Check: {}", USER_NOT_CONFIRMED_IDP);
                             return USER_NOT_CONFIRMED_IDP;
                         }
-                    } catch (final ShouldNotHappenException e) {
+                    } catch (final InvalidUserStatusException e) {
                         logger.error("User Status Check: {}", USER_STATUS_UNKNOWN);
                         return USER_STATUS_UNKNOWN;
                     }
@@ -335,15 +335,15 @@ public class OpenScienceFrameworkAuthenticationHandler extends AbstractPreAndPos
      *
      * @param externalIdentity a {@link JsonObject} that stores all external identities of a user instance
      * @return {@code true} if so and {@code false} otherwise
-     * @throws ShouldNotHappenException if {@code externalIdentity} fails JSON parsing.
+     * @throws InvalidUserStatusException if {@code externalIdentity} fails JSON parsing.
      */
-    private boolean isCreatedByExternalIdp(final JsonObject externalIdentity) throws ShouldNotHappenException {
+    private boolean isCreatedByExternalIdp(final JsonObject externalIdentity) throws InvalidUserStatusException {
 
         for (final Map.Entry<String, JsonElement> provider : externalIdentity.entrySet()) {
             try {
                 for (final Map.Entry<String, JsonElement> identity : provider.getValue().getAsJsonObject().entrySet()) {
                     if (!identity.getValue().isJsonPrimitive()) {
-                        throw new ShouldNotHappenException();
+                        throw new InvalidUserStatusException();
                     }
                     if ("CREATE".equals(identity.getValue().getAsString())) {
                         logger.info("New and unconfirmed OSF user: {} : {}", identity.getKey(), identity.getValue().toString());
@@ -351,7 +351,7 @@ public class OpenScienceFrameworkAuthenticationHandler extends AbstractPreAndPos
                     }
                 }
             } catch (final IllegalStateException e) {
-                throw new ShouldNotHappenException();
+                throw new InvalidUserStatusException();
             }
         }
         return false;

--- a/cas-server-support-osf/src/main/java/io/cos/cas/adaptors/postgres/handlers/OpenScienceFrameworkAuthenticationHandler.java
+++ b/cas-server-support-osf/src/main/java/io/cos/cas/adaptors/postgres/handlers/OpenScienceFrameworkAuthenticationHandler.java
@@ -24,11 +24,11 @@ import io.cos.cas.adaptors.postgres.models.OpenScienceFrameworkTimeBasedOneTimeP
 import io.cos.cas.adaptors.postgres.models.OpenScienceFrameworkUser;
 import io.cos.cas.authentication.exceptions.AccountNotConfirmedIdPLoginException;
 import io.cos.cas.authentication.exceptions.AccountNotConfirmedOsfLoginException;
-import io.cos.cas.authentication.InvalidVerificationKeyException;
-import io.cos.cas.authentication.OneTimePasswordFailedLoginException;
-import io.cos.cas.authentication.OneTimePasswordRequiredException;
+import io.cos.cas.authentication.exceptions.InvalidVerificationKeyException;
+import io.cos.cas.authentication.exceptions.OneTimePasswordFailedLoginException;
+import io.cos.cas.authentication.exceptions.OneTimePasswordRequiredException;
 import io.cos.cas.authentication.OpenScienceFrameworkCredential;
-import io.cos.cas.authentication.ShouldNotHappenException;
+import io.cos.cas.authentication.exceptions.ShouldNotHappenException;
 import io.cos.cas.authentication.oath.TotpUtils;
 
 import org.jasig.cas.authentication.AccountDisabledException;

--- a/cas-server-support-osf/src/main/java/io/cos/cas/authentication/exceptions/CasClientLoginException.java
+++ b/cas-server-support-osf/src/main/java/io/cos/cas/authentication/exceptions/CasClientLoginException.java
@@ -22,7 +22,7 @@ package io.cos.cas.authentication.exceptions;
  * {@link org.jasig.cas.support.pac4j.web.flow.ClientAction} and {@link org.pac4j.cas.client.CasClient}.
  *
  * @author Longze Chen
- * @since 4.1.5
+ * @since 19.3.0
  */
 public class CasClientLoginException extends DelegatedLoginException {
 

--- a/cas-server-support-osf/src/main/java/io/cos/cas/authentication/exceptions/DelegatedLoginException.java
+++ b/cas-server-support-osf/src/main/java/io/cos/cas/authentication/exceptions/DelegatedLoginException.java
@@ -23,7 +23,7 @@ import javax.security.auth.login.FailedLoginException;
  * This is a generic login exception for authentication via delegated client.
  *
  * @author Longze Chen
- * @since 4.1.5
+ * @since 19.3.0
  */
 public class DelegatedLoginException extends FailedLoginException {
 

--- a/cas-server-support-osf/src/main/java/io/cos/cas/authentication/exceptions/InvalidUserStatusException.java
+++ b/cas-server-support-osf/src/main/java/io/cos/cas/authentication/exceptions/InvalidUserStatusException.java
@@ -18,21 +18,22 @@ package io.cos.cas.authentication.exceptions;
 import javax.security.auth.login.AccountException;
 
 /**
- * Describes an error condition where authentication occurs from an account that:
+ * Describes an error condition where user status is invalid, which currently includes the following cases.
  *
  * 1. is an unclaimed user which has been created as a new contributor
  * 2. is an inactive user which has been merged into another account
- * 3. has other undefined/unknown status, possibly due to internal bug or user model changes
+ * 3. has an external identity that can not be parsed
+ * 4. has other undefined status, possibly due to internal bug or user model changes
  *
  * @author Longze Chen
  * @since 20.1.0
  */
-public class ShouldNotHappenException extends AccountException {
+public class InvalidUserStatusException extends AccountException {
 
     private static final long serialVersionUID = 8296529645368130304L;
 
     /** Instantiates a new exception (default). */
-    public ShouldNotHappenException() {
+    public InvalidUserStatusException() {
         super();
     }
 
@@ -41,7 +42,7 @@ public class ShouldNotHappenException extends AccountException {
      *
      * @param message the message
      */
-    public ShouldNotHappenException(final String message) {
+    public InvalidUserStatusException(final String message) {
         super(message);
     }
 }

--- a/cas-server-support-osf/src/main/java/io/cos/cas/authentication/exceptions/InvalidVerificationKeyException.java
+++ b/cas-server-support-osf/src/main/java/io/cos/cas/authentication/exceptions/InvalidVerificationKeyException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016. Center for Open Science
+ * Copyright (c) 2020. Center for Open Science
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,26 +13,22 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.cos.cas.authentication;
+package io.cos.cas.authentication.exceptions;
 
 import javax.security.auth.login.AccountException;
 
 /**
- * Describes an error condition where authentication occurs from an account that:
- *
- * 1. is an unclaimed user which has been created as a new contributor
- * 2. is an inactive user which has been merged into another account
- * 3. has other undefined/unknown status, possibly due to internal bug or user model changes
+ * Describes an error condition where authentication failed with invalid verification key.
  *
  * @author Longze Chen
- * @since 4.1.5
+ * @since 20.1.0
  */
-public class ShouldNotHappenException extends AccountException {
+public class InvalidVerificationKeyException extends AccountException {
 
-    private static final long serialVersionUID = 8296529645368130304L;
+    private static final long serialVersionUID = -4572658985746454304L;
 
     /** Instantiates a new exception (default). */
-    public ShouldNotHappenException() {
+    public InvalidVerificationKeyException() {
         super();
     }
 
@@ -41,7 +37,7 @@ public class ShouldNotHappenException extends AccountException {
      *
      * @param message the message
      */
-    public ShouldNotHappenException(final String message) {
+    public InvalidVerificationKeyException(final String message) {
         super(message);
     }
 }

--- a/cas-server-support-osf/src/main/java/io/cos/cas/authentication/exceptions/OneTimePasswordFailedLoginException.java
+++ b/cas-server-support-osf/src/main/java/io/cos/cas/authentication/exceptions/OneTimePasswordFailedLoginException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015. Center for Open Science
+ * Copyright (c) 2020. Center for Open Science
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.cos.cas.authentication;
+package io.cos.cas.authentication.exceptions;
 
 import javax.security.auth.login.AccountException;
 
@@ -22,7 +22,7 @@ import javax.security.auth.login.AccountException;
  *
  * @author Michael Haselton
  * @author Longze Chen
- * @since 4.1.5
+ * @since 20.1.0
  */
 public class OneTimePasswordFailedLoginException extends AccountException {
 

--- a/cas-server-support-osf/src/main/java/io/cos/cas/authentication/exceptions/OneTimePasswordRequiredException.java
+++ b/cas-server-support-osf/src/main/java/io/cos/cas/authentication/exceptions/OneTimePasswordRequiredException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015. Center for Open Science
+ * Copyright (c) 2020. Center for Open Science
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.cos.cas.authentication;
+package io.cos.cas.authentication.exceptions;
 
 import javax.security.auth.login.AccountException;
 
@@ -22,7 +22,7 @@ import javax.security.auth.login.AccountException;
  *
  * @author Michael Haselton
  * @author Longze Chen
- * @since 4.1.5
+ * @since 20.1.0
  */
 public class OneTimePasswordRequiredException extends AccountException {
 

--- a/cas-server-support-osf/src/main/java/io/cos/cas/authentication/exceptions/OrcidClientLoginException.java
+++ b/cas-server-support-osf/src/main/java/io/cos/cas/authentication/exceptions/OrcidClientLoginException.java
@@ -22,7 +22,7 @@ package io.cos.cas.authentication.exceptions;
  * {@link org.jasig.cas.support.pac4j.web.flow.ClientAction} and {@link org.pac4j.oauth.client.OrcidClient}.
  *
  * @author Longze Chen
- * @since 4.1.5
+ * @since 19.3.0
  */
 public class OrcidClientLoginException extends DelegatedLoginException {
 

--- a/cas-server-support-osf/src/main/java/io/cos/cas/authentication/exceptions/RemoteUserFailedLoginException.java
+++ b/cas-server-support-osf/src/main/java/io/cos/cas/authentication/exceptions/RemoteUserFailedLoginException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016. Center for Open Science
+ * Copyright (c) 2020. Center for Open Science
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.cos.cas.authentication;
+package io.cos.cas.authentication.exceptions;
 
 import javax.security.auth.login.AccountException;
 
@@ -22,7 +22,7 @@ import javax.security.auth.login.AccountException;
  *
  * @author Michael Haselton
  * @author Longze Chen
- * @since 4.1.5
+ * @since 20.1.0
  */
 public class RemoteUserFailedLoginException extends AccountException {
 

--- a/cas-server-support-osf/src/main/java/io/cos/cas/authentication/exceptions/RemoteUserFailedLoginException.java
+++ b/cas-server-support-osf/src/main/java/io/cos/cas/authentication/exceptions/RemoteUserFailedLoginException.java
@@ -18,7 +18,11 @@ package io.cos.cas.authentication.exceptions;
 import javax.security.auth.login.AccountException;
 
 /**
- * Describes an error condition where authentication has failed during authentication delegation.
+ * Describes an error condition where authentication has failed during institutional authentication delegation.
+ *
+ * TODO: Divide this exception into two or more detailed ones. For example, one for failure in parsing required
+ *       attributes from authenticated Shibboleth session (InstitutionLoginFailedException), one for failure in
+ *       communicating with OSF API (OsfApiFailedException), etc.
  *
  * @author Michael Haselton
  * @author Longze Chen

--- a/cas-server-support-osf/src/main/java/io/cos/cas/authentication/exceptions/ShouldNotHappenException.java
+++ b/cas-server-support-osf/src/main/java/io/cos/cas/authentication/exceptions/ShouldNotHappenException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018. Center for Open Science
+ * Copyright (c) 2020. Center for Open Science
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,22 +13,26 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.cos.cas.authentication;
+package io.cos.cas.authentication.exceptions;
 
 import javax.security.auth.login.AccountException;
 
 /**
- * Describes an error condition where authentication failed with invalid verification key.
+ * Describes an error condition where authentication occurs from an account that:
+ *
+ * 1. is an unclaimed user which has been created as a new contributor
+ * 2. is an inactive user which has been merged into another account
+ * 3. has other undefined/unknown status, possibly due to internal bug or user model changes
  *
  * @author Longze Chen
- * @since 4.1.5
+ * @since 20.1.0
  */
-public class InvalidVerificationKeyException extends AccountException {
+public class ShouldNotHappenException extends AccountException {
 
-    private static final long serialVersionUID = -4572658985746454304L;
+    private static final long serialVersionUID = 8296529645368130304L;
 
     /** Instantiates a new exception (default). */
-    public InvalidVerificationKeyException() {
+    public ShouldNotHappenException() {
         super();
     }
 
@@ -37,7 +41,7 @@ public class InvalidVerificationKeyException extends AccountException {
      *
      * @param message the message
      */
-    public InvalidVerificationKeyException(final String message) {
+    public ShouldNotHappenException(final String message) {
         super(message);
     }
 }

--- a/cas-server-support-osf/src/main/java/io/cos/cas/authentication/handler/support/OpenScienceFrameworkPrincipalFromRequestRemoteUserNonInteractiveCredentialsAction.java
+++ b/cas-server-support-osf/src/main/java/io/cos/cas/authentication/handler/support/OpenScienceFrameworkPrincipalFromRequestRemoteUserNonInteractiveCredentialsAction.java
@@ -15,6 +15,8 @@
  */
 package io.cos.cas.authentication.handler.support;
 
+import com.nimbusds.jose.crypto.DirectEncrypter;
+import com.nimbusds.jose.crypto.MACSigner;
 import com.nimbusds.jose.EncryptionMethod;
 import com.nimbusds.jose.JOSEException;
 import com.nimbusds.jose.JWEAlgorithm;
@@ -24,20 +26,20 @@ import com.nimbusds.jose.JWSAlgorithm;
 import com.nimbusds.jose.JWSHeader;
 import com.nimbusds.jose.JWSSigner;
 import com.nimbusds.jose.Payload;
-import com.nimbusds.jose.crypto.DirectEncrypter;
-import com.nimbusds.jose.crypto.MACSigner;
 import com.nimbusds.jwt.JWTClaimsSet;
 import com.nimbusds.jwt.SignedJWT;
+
 import io.cos.cas.adaptors.postgres.types.DelegationProtocol;
-import io.cos.cas.authentication.OpenScienceFrameworkCredential;
 import io.cos.cas.authentication.exceptions.RemoteUserFailedLoginException;
-import org.apache.http.HttpResponse;
-import org.apache.http.HttpStatus;
+import io.cos.cas.authentication.OpenScienceFrameworkCredential;
+
 import org.apache.http.client.fluent.Request;
 import org.apache.http.entity.ContentType;
+import org.apache.http.HttpResponse;
+import org.apache.http.HttpStatus;
 import org.apache.http.impl.client.BasicResponseHandler;
 import org.apache.http.message.BasicHeader;
-import org.jasig.cas.CentralAuthenticationService;
+
 import org.jasig.cas.authentication.Authentication;
 import org.jasig.cas.authentication.AuthenticationException;
 import org.jasig.cas.authentication.Credential;
@@ -45,22 +47,28 @@ import org.jasig.cas.authentication.principal.DefaultPrincipalFactory;
 import org.jasig.cas.authentication.principal.Principal;
 import org.jasig.cas.authentication.principal.PrincipalFactory;
 import org.jasig.cas.authentication.principal.Service;
+import org.jasig.cas.CentralAuthenticationService;
 import org.jasig.cas.ticket.InvalidTicketException;
 import org.jasig.cas.ticket.ServiceTicket;
 import org.jasig.cas.ticket.TicketException;
 import org.jasig.cas.ticket.TicketGrantingTicket;
 import org.jasig.cas.web.support.WebUtils;
+
 import org.json.JSONObject;
 import org.json.XML;
+
 import org.pac4j.oauth.client.OrcidClient;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
 import org.springframework.util.ResourceUtils;
 import org.springframework.util.StringUtils;
 import org.springframework.webflow.action.AbstractAction;
 import org.springframework.webflow.core.collection.LocalAttributeMap;
 import org.springframework.webflow.execution.Event;
 import org.springframework.webflow.execution.RequestContext;
+
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
@@ -78,6 +86,7 @@ import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
 import javax.xml.transform.stream.StreamSource;
+
 import java.io.File;
 import java.io.IOException;
 import java.io.StringWriter;
@@ -86,8 +95,8 @@ import java.util.Date;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
-
 /**
+ *
  * Implementation of the NonInteractiveCredentialsAction that looks for a remote
  * user that is set in the <code>HttpServletRequest</code> and attempts to
  * construct a Principal (and thus a PrincipalBearingCredential). If it doesn't
@@ -99,17 +108,18 @@ import java.util.Map;
  *  2.  Institution login Using CAS with implementation from pac4j
  *  3.  Normal login with username and verification key
  *
+ * TODO: rewrite this outdated JavaDoc along with refactoring {@link RemoteUserFailedLoginException}
+ *
  * @author Michael Haselton
  * @author Longze Chen
- * @since 4.1.5
+ * @since 19.3.0
  */
-public class OpenScienceFrameworkPrincipalFromRequestRemoteUserNonInteractiveCredentialsAction
-            extends AbstractAction {
+public class OpenScienceFrameworkPrincipalFromRequestRemoteUserNonInteractiveCredentialsAction extends AbstractAction {
     /**
      * The Principal Authentication Result.
      *
      * @author Longze Chen
-     * @since 4.1.5
+     * @since 19.3.0
      */
     public static class PrincipalAuthenticationResult {
 

--- a/cas-server-support-osf/src/main/java/io/cos/cas/authentication/handler/support/OpenScienceFrameworkPrincipalFromRequestRemoteUserNonInteractiveCredentialsAction.java
+++ b/cas-server-support-osf/src/main/java/io/cos/cas/authentication/handler/support/OpenScienceFrameworkPrincipalFromRequestRemoteUserNonInteractiveCredentialsAction.java
@@ -30,7 +30,7 @@ import com.nimbusds.jwt.JWTClaimsSet;
 import com.nimbusds.jwt.SignedJWT;
 import io.cos.cas.adaptors.postgres.types.DelegationProtocol;
 import io.cos.cas.authentication.OpenScienceFrameworkCredential;
-import io.cos.cas.authentication.RemoteUserFailedLoginException;
+import io.cos.cas.authentication.exceptions.RemoteUserFailedLoginException;
 import org.apache.http.HttpResponse;
 import org.apache.http.HttpStatus;
 import org.apache.http.client.fluent.Request;

--- a/cas-server-support-osf/src/main/java/io/cos/cas/web/flow/OpenScienceFrameworkAuthenticationExceptionHandler.java
+++ b/cas-server-support-osf/src/main/java/io/cos/cas/web/flow/OpenScienceFrameworkAuthenticationExceptionHandler.java
@@ -24,12 +24,12 @@ import io.cos.cas.authentication.exceptions.AccountNotConfirmedIdPLoginException
 import io.cos.cas.authentication.exceptions.AccountNotConfirmedOsfLoginException;
 import io.cos.cas.authentication.exceptions.CasClientLoginException;
 import io.cos.cas.authentication.exceptions.DelegatedLoginException;
-import io.cos.cas.authentication.exceptions.OrcidClientLoginException;
+import io.cos.cas.authentication.exceptions.InvalidUserStatusException;
 import io.cos.cas.authentication.exceptions.InvalidVerificationKeyException;
 import io.cos.cas.authentication.exceptions.OneTimePasswordFailedLoginException;
 import io.cos.cas.authentication.exceptions.OneTimePasswordRequiredException;
+import io.cos.cas.authentication.exceptions.OrcidClientLoginException;
 import io.cos.cas.authentication.exceptions.RemoteUserFailedLoginException;
-import io.cos.cas.authentication.exceptions.ShouldNotHappenException;
 
 import org.jasig.cas.authentication.AccountDisabledException;
 import org.jasig.cas.authentication.AccountPasswordMustChangeException;
@@ -64,42 +64,42 @@ public class OpenScienceFrameworkAuthenticationExceptionHandler extends Authenti
 
     // Built-in exceptions that are not explicitly used
     static {
+        DEFAULT_ERROR_LIST.add(AccountLockedException.class);
         DEFAULT_ERROR_LIST.add(AccountPasswordMustChangeException.class);
+        DEFAULT_ERROR_LIST.add(CredentialExpiredException.class);
         DEFAULT_ERROR_LIST.add(InvalidLoginLocationException.class);
         DEFAULT_ERROR_LIST.add(InvalidLoginTimeException.class);
-        DEFAULT_ERROR_LIST.add(AccountLockedException.class);
-        DEFAULT_ERROR_LIST.add(CredentialExpiredException.class);
     }
 
     // Built-in exceptions that are used for OSF
     static {
-        DEFAULT_ERROR_LIST.add(FailedLoginException.class);
         DEFAULT_ERROR_LIST.add(AccountDisabledException.class);
         DEFAULT_ERROR_LIST.add(AccountNotFoundException.class);
+        DEFAULT_ERROR_LIST.add(FailedLoginException.class);
     }
 
     // Customized exceptions for OSF
     static {
-        DEFAULT_ERROR_LIST.add(InvalidVerificationKeyException.class);
         DEFAULT_ERROR_LIST.add(AccountNotConfirmedOsfLoginException.class);
         DEFAULT_ERROR_LIST.add(AccountNotConfirmedIdPLoginException.class);
-        DEFAULT_ERROR_LIST.add(ShouldNotHappenException.class);
-        DEFAULT_ERROR_LIST.add(RemoteUserFailedLoginException.class);
+        DEFAULT_ERROR_LIST.add(InvalidVerificationKeyException.class);
+        DEFAULT_ERROR_LIST.add(InvalidUserStatusException.class);
         DEFAULT_ERROR_LIST.add(OneTimePasswordFailedLoginException.class);
         DEFAULT_ERROR_LIST.add(OneTimePasswordRequiredException.class);
+        DEFAULT_ERROR_LIST.add(RemoteUserFailedLoginException.class);
     }
 
     // Customized exceptions for delegated login
     static {
+        DEFAULT_ERROR_LIST.add(CasClientLoginException.class);
         DEFAULT_ERROR_LIST.add(DelegatedLoginException.class);
         DEFAULT_ERROR_LIST.add(OrcidClientLoginException.class);
-        DEFAULT_ERROR_LIST.add(CasClientLoginException.class);
     }
 
     // Exceptions that should count against the login rate limiting
     static {
-        THROTTLE_INCREASE_SET.add(FailedLoginException.class.getSimpleName());                // Wrong password
         THROTTLE_INCREASE_SET.add(AccountNotFoundException.class.getSimpleName());            // Username does not exist
+        THROTTLE_INCREASE_SET.add(FailedLoginException.class.getSimpleName());                // Wrong password
         THROTTLE_INCREASE_SET.add(OneTimePasswordFailedLoginException.class.getSimpleName()); // Wrong one time password
     }
 

--- a/cas-server-support-osf/src/main/java/io/cos/cas/web/flow/OpenScienceFrameworkAuthenticationExceptionHandler.java
+++ b/cas-server-support-osf/src/main/java/io/cos/cas/web/flow/OpenScienceFrameworkAuthenticationExceptionHandler.java
@@ -25,11 +25,11 @@ import io.cos.cas.authentication.exceptions.AccountNotConfirmedOsfLoginException
 import io.cos.cas.authentication.exceptions.CasClientLoginException;
 import io.cos.cas.authentication.exceptions.DelegatedLoginException;
 import io.cos.cas.authentication.exceptions.OrcidClientLoginException;
-import io.cos.cas.authentication.InvalidVerificationKeyException;
-import io.cos.cas.authentication.OneTimePasswordFailedLoginException;
-import io.cos.cas.authentication.OneTimePasswordRequiredException;
-import io.cos.cas.authentication.RemoteUserFailedLoginException;
-import io.cos.cas.authentication.ShouldNotHappenException;
+import io.cos.cas.authentication.exceptions.InvalidVerificationKeyException;
+import io.cos.cas.authentication.exceptions.OneTimePasswordFailedLoginException;
+import io.cos.cas.authentication.exceptions.OneTimePasswordRequiredException;
+import io.cos.cas.authentication.exceptions.RemoteUserFailedLoginException;
+import io.cos.cas.authentication.exceptions.ShouldNotHappenException;
 
 import org.jasig.cas.authentication.AccountDisabledException;
 import org.jasig.cas.authentication.AccountPasswordMustChangeException;

--- a/cas-server-support-osf/src/test/java/io/cos/cas/AbstractTestUtils.java
+++ b/cas-server-support-osf/src/test/java/io/cos/cas/AbstractTestUtils.java
@@ -19,7 +19,7 @@ import java.util.Map;
  *  Abstract Test Util Class.
  *
  *  @author Longze Chen
- *  @since  4.1.5
+ *  @since  19.3.0
  */
 public abstract class AbstractTestUtils {
 

--- a/cas-server-support-osf/src/test/java/io/cos/cas/authentication/handler/support/OpenScienceFrameworkPrincipalFromRequestRemoteUserNonInteractiveCredentialsActionTests.java
+++ b/cas-server-support-osf/src/test/java/io/cos/cas/authentication/handler/support/OpenScienceFrameworkPrincipalFromRequestRemoteUserNonInteractiveCredentialsActionTests.java
@@ -2,13 +2,13 @@ package io.cos.cas.authentication.handler.support;
 
 import io.cos.cas.AbstractTestUtils;
 import io.cos.cas.adaptors.postgres.types.DelegationProtocol;
-import io.cos.cas.authentication.OpenScienceFrameworkCredential;
 import io.cos.cas.authentication.exceptions.RemoteUserFailedLoginException;
+import io.cos.cas.authentication.OpenScienceFrameworkCredential;
 import io.cos.cas.mock.MockNormalizeRemotePrincipal;
 import io.cos.cas.mock.MockNotifyRemotePrincipalAuthenticated;
 
-import org.jasig.cas.CentralAuthenticationService;
 import org.jasig.cas.authentication.Authentication;
+import org.jasig.cas.CentralAuthenticationService;
 import org.jasig.cas.ticket.TicketGrantingTicket;
 
 import org.junit.Test;
@@ -18,6 +18,7 @@ import org.springframework.webflow.execution.Event;
 import org.springframework.webflow.test.MockRequestContext;
 
 import javax.security.auth.login.AccountException;
+
 import java.util.Collections;
 
 import static org.junit.Assert.assertEquals;
@@ -33,7 +34,7 @@ import static org.mockito.Mockito.when;
  * This class tests the {@link OpenScienceFrameworkPrincipalFromRequestRemoteUserNonInteractiveCredentialsAction} class.
  *
  * @author Longze Chen
- * @since  4.1.5
+ * @since  19.3.0
  */
 public class OpenScienceFrameworkPrincipalFromRequestRemoteUserNonInteractiveCredentialsActionTests {
 

--- a/cas-server-support-osf/src/test/java/io/cos/cas/authentication/handler/support/OpenScienceFrameworkPrincipalFromRequestRemoteUserNonInteractiveCredentialsActionTests.java
+++ b/cas-server-support-osf/src/test/java/io/cos/cas/authentication/handler/support/OpenScienceFrameworkPrincipalFromRequestRemoteUserNonInteractiveCredentialsActionTests.java
@@ -3,7 +3,7 @@ package io.cos.cas.authentication.handler.support;
 import io.cos.cas.AbstractTestUtils;
 import io.cos.cas.adaptors.postgres.types.DelegationProtocol;
 import io.cos.cas.authentication.OpenScienceFrameworkCredential;
-import io.cos.cas.authentication.RemoteUserFailedLoginException;
+import io.cos.cas.authentication.exceptions.RemoteUserFailedLoginException;
 import io.cos.cas.mock.MockNormalizeRemotePrincipal;
 import io.cos.cas.mock.MockNotifyRemotePrincipalAuthenticated;
 

--- a/cas-server-support-osf/src/test/java/io/cos/cas/mock/MockNormalizeRemotePrincipal.java
+++ b/cas-server-support-osf/src/test/java/io/cos/cas/mock/MockNormalizeRemotePrincipal.java
@@ -7,10 +7,10 @@ import org.jasig.cas.CentralAuthenticationService;
 import org.json.JSONObject;
 
 /**
- * This class mocks the {@link OpenScienceFrameworkPrincipalFromRequestRemoteUserNonInteractiveCredentialsAction} class.
+ * This class mocks the {@code OpenScienceFrameworkPrincipalFromRequestRemoteUserNonInteractiveCredentialsAction} class.
  *
  * @author Longze Chen
- * @since  4.1.5
+ * @since  19.3.0
  */
 public class MockNormalizeRemotePrincipal extends MockOsfRemoteAuthenticateAction {
 

--- a/cas-server-support-osf/src/test/java/io/cos/cas/mock/MockNotifyRemotePrincipalAuthenticated.java
+++ b/cas-server-support-osf/src/test/java/io/cos/cas/mock/MockNotifyRemotePrincipalAuthenticated.java
@@ -8,10 +8,10 @@ import org.jasig.cas.CentralAuthenticationService;
 import javax.security.auth.login.AccountException;
 
 /**
- * This class mocks the {@link OpenScienceFrameworkPrincipalFromRequestRemoteUserNonInteractiveCredentialsAction} class.
+ * This class mocks the {@code OpenScienceFrameworkPrincipalFromRequestRemoteUserNonInteractiveCredentialsAction} class.
  *
  * @author Longze Chen
- * @since  4.1.5
+ * @since  19.3.0
  */
 public class MockNotifyRemotePrincipalAuthenticated extends MockOsfRemoteAuthenticateAction {
 

--- a/cas-server-support-osf/src/test/java/io/cos/cas/mock/MockOsfRemoteAuthenticateAction.java
+++ b/cas-server-support-osf/src/test/java/io/cos/cas/mock/MockOsfRemoteAuthenticateAction.java
@@ -8,10 +8,10 @@ import org.jasig.cas.CentralAuthenticationService;
  * This class mocks the {@link OpenScienceFrameworkPrincipalFromRequestRemoteUserNonInteractiveCredentialsAction} class.
  *
  * @author Longze Chen
- * @since  4.1.5
+ * @since  19.3.0
  */
 public class MockOsfRemoteAuthenticateAction
-    extends OpenScienceFrameworkPrincipalFromRequestRemoteUserNonInteractiveCredentialsAction {
+        extends OpenScienceFrameworkPrincipalFromRequestRemoteUserNonInteractiveCredentialsAction {
 
     protected static final String INSTITUTION_AUTH_URL = "institution_auth_url";
     protected static final String INSTITUTION_AUTH_JWE_SECRET = "osf_api_cas_login_jwe_secret_32b";

--- a/cas-server-webapp/src/main/resources/messages.properties
+++ b/cas-server-webapp/src/main/resources/messages.properties
@@ -151,8 +151,8 @@ screen.accountnotconfirmed.idplogin.heading=Account not confirmed
 screen.accountnotconfirmed.idplogin.message=The OSF account associated with the email has been registered but not confirmed. Our records show that this account was created via ORCiD login. Please check your email (and spam folder) for the confirmation link. If you believe this should not happen, please contact <a style="white-space: nowrap" href="mailto:support@osf.io">OSF Support</a>.
 screen.accountdisabled.heading=Account disabled
 screen.accountdisabled.message=The OSF account associated with the email has been disabled.  Please contact <a style="white-space: nowrap" href="mailto:support@osf.io">OSF Support</a> to regain access.
-screen.shouldnothappen.heading=Account not active
-screen.shouldnothappen.message=Cannot login to an inactive account.  If you believe this should not happen, please contact <a style="white-space: nowrap" href="mailto:support@osf.io">OSF Support</a>.
+screen.invaliduserstatus.heading=Account not valid
+screen.invaliduserstatus.message=Cannot log in to an invalid account.  If you believe this should not happen, please contact <a style="white-space: nowrap" href="mailto:support@osf.io">OSF Support</a>.
 screen.invalidVerificationKey.heading=Invalid Verification Key
 screen.invalidVerificationKey.message=Automatic login has failed due to invalid one-time verification key.  This key may have expired or have already been used.
 

--- a/cas-server-webapp/src/main/webapp/WEB-INF/view/jsp/default/ui/casInvalidUserStatus.jsp
+++ b/cas-server-webapp/src/main/webapp/WEB-INF/view/jsp/default/ui/casInvalidUserStatus.jsp
@@ -21,8 +21,8 @@
 <jsp:directive.include file="includes/top.jsp"/>
 
 <div id="msg" class="errors">
-    <h2><spring:message code="screen.shouldnothappen.heading"/></h2>
-    <p><spring:message code="screen.shouldnothappen.message"/></p>
+    <h2><spring:message code="screen.invaliduserstatus.heading"/></h2>
+    <p><spring:message code="screen.invaliduserstatus.message"/></p>
 </div>
 
 <spring:message code="screen.osf.login.message.error" var="errorDescription"/>

--- a/cas-server-webapp/src/main/webapp/WEB-INF/webflow/login/login-webflow.xml
+++ b/cas-server-webapp/src/main/webapp/WEB-INF/webflow/login/login-webflow.xml
@@ -199,21 +199,21 @@
         <transition on="InvalidLoginLocationException" to="casBadWorkstationView"/>
         <transition on="InvalidLoginTimeException" to="casBadHoursView"/>
         <!-- Built-in exceptions that are explicitly used by OSF -->
-        <transition on="FailedLoginException" to="generateLoginTicket"/>
         <transition on="AccountNotFoundException" to="generateLoginTicket"/>
         <transition on="AccountDisabledException" to="casAccountDisabledView"/>
+        <transition on="FailedLoginException" to="generateLoginTicket"/>
         <!-- Customized exceptions for OSF -->
-        <transition on="InvalidVerificationKeyException" to="casInvalidVerificationKeyView" />
-        <transition on="AccountNotConfirmedOsfLoginException" to="casAccountNotConfirmedOsfLoginView" />
-        <transition on="AccountNotConfirmedIdPLoginException" to="casAccountNotConfirmedIdPLoginView" />
-        <transition on="ShouldNotHappenException" to="casShouldNotHappenView" />
-        <transition on="RemoteUserFailedLoginException" to="casRemoteUserFailedLoginView" />
+        <transition on="AccountNotConfirmedOsfLoginException" to="casAccountNotConfirmedOsfLoginView"/>
+        <transition on="AccountNotConfirmedIdPLoginException" to="casAccountNotConfirmedIdPLoginView"/>
+        <transition on="InvalidUserStatusException" to="casInvalidUserStatusView"/>
+        <transition on="InvalidVerificationKeyException" to="casInvalidVerificationKeyView"/>
         <transition on="OneTimePasswordRequiredException" to="casOtpLoginView"/>
         <transition on="OneTimePasswordFailedLoginException" to="casOtpLoginView"/>
+        <transition on="RemoteUserFailedLoginException" to="casRemoteUserFailedLoginView"/>
         <!-- Customized exceptions for delegated login -->
-        <transition on="DelegatedLoginException" to="delegatedLoginGenericErrorView" />
         <transition on="CasClientLoginException" to="delegatedLoginCasErrorView"/>
         <transition on="OrcidClientLoginException" to="delegatedLoginOrcidErrorView"/>
+        <transition on="DelegatedLoginException" to="delegatedLoginGenericErrorView"/>
         <!-- Unhandled Exceptions -->
         <transition on="UNKNOWN" to="generateLoginTicket"/>
     </action-state>
@@ -277,19 +277,21 @@
             <set name="flowScope.passwordPolicyUrl" value="passwordPolicy.passwordPolicyUrl"/>
         </on-entry>
     </end-state>
+    <!-- CAS Built-in Exception Views -->
     <end-state id="casExpiredPassView" view="casExpiredPassView" parent="#abstactPasswordChangeView"/>
     <end-state id="casMustChangePassView" view="casMustChangePassView" parent="#abstactPasswordChangeView"/>
-    <end-state id="casAccountDisabledView" view="casAccountDisabledView"/>
     <end-state id="casAccountLockedView" view="casAccountLockedView"/>
     <end-state id="casBadHoursView" view="casBadHoursView"/>
     <end-state id="casBadWorkstationView" view="casBadWorkstationView"/>
-    <end-state id="casAccountNotConfirmedOsfLoginView" view="casAccountNotConfirmedOsfLoginView" />
+    <!-- OSF Customized Exception Views -->
+    <end-state id="casAccountDisabledView" view="casAccountDisabledView"/>
     <end-state id="casAccountNotConfirmedIdPLoginView" view="casAccountNotConfirmedIdPLoginView" />
-    <end-state id="casShouldNotHappenView" view="casShouldNotHappenView" />
-    <end-state id="casRemoteUserFailedLoginView" view="casRemoteUserFailedLoginView" />
-    <end-state id="casInvalidVerificationKeyView" view="casInvalidVerificationKeyView" />
-    <end-state id="delegatedLoginGenericErrorView" view="delegatedLoginGenericErrorView" />
-    <end-state id="delegatedLoginCasErrorView" view="delegatedLoginCasErrorView" />
+    <end-state id="casAccountNotConfirmedOsfLoginView" view="casAccountNotConfirmedOsfLoginView" />
+    <end-state id="casInvalidUserStatusView" view="casInvalidUserStatusView"/>
+    <end-state id="casInvalidVerificationKeyView" view="casInvalidVerificationKeyView"/>
+    <end-state id="casRemoteUserFailedLoginView" view="casRemoteUserFailedLoginView"/>
+    <end-state id="delegatedLoginCasErrorView" view="delegatedLoginCasErrorView"/>
+    <end-state id="delegatedLoginGenericErrorView" view="delegatedLoginGenericErrorView"/>
     <end-state id="delegatedLoginOrcidErrorView" view="delegatedLoginOrcidErrorView" />
 
     <end-state id="postView" view="postResponseView">


### PR DESCRIPTION
## Ticket

https://openscience.atlassian.net/browse/ENG-1205

## Purpose

* Moved all CAS exceptions to `io.cos.cas.authentication.exceptions`
* Renamed exception "shouldNotHappen" to "invalidUserStatus"
* Added a TODO comment to split exception "remoteUserFailedLogin" 

## Changes

See above

## Dev / QA Notes

QA notes will developed in the following test ticket as a template for testing CAS in the future.

## Dev-Ops Notes

N / A

