### PR TITLE
[ENG-1107] OSF TBOTP: `deleted` from Boolean to TIMESTAMP

### DIFF
--- a/cas-server-support-osf/src/main/java/io/cos/cas/adaptors/postgres/models/OpenScienceFrameworkTimeBasedOneTimePassword.java
+++ b/cas-server-support-osf/src/main/java/io/cos/cas/adaptors/postgres/models/OpenScienceFrameworkTimeBasedOneTimePassword.java
@@ -23,14 +23,19 @@ import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.OneToOne;
 import javax.persistence.Table;
+import javax.persistence.Temporal;
+import javax.persistence.TemporalType;
+
 import javax.xml.bind.DatatypeConverter;
+
+import java.util.Date;
 
 /**
  * The Open Science Framework Two Factor User Settings.
  *
  * @author Michael Haselton
  * @author Longze Chen
- * @since 4.1.0
+ * @since 19.3.0
  */
 @Entity
 @Table(name = "addons_twofactor_usersettings")
@@ -50,8 +55,9 @@ public class OpenScienceFrameworkTimeBasedOneTimePassword {
     @Column(name = "is_confirmed", nullable = false)
     private Boolean confirmed;
 
-    @Column(name = "is_deleted", nullable = false)
-    private Boolean deleted;
+    @Temporal(TemporalType.TIMESTAMP)
+    @Column(name = "deleted")
+    private Date deleted;
 
     /** Default Constructor. */
     public OpenScienceFrameworkTimeBasedOneTimePassword() {}
@@ -69,7 +75,7 @@ public class OpenScienceFrameworkTimeBasedOneTimePassword {
     }
 
     public Boolean isDeleted() {
-        return deleted;
+        return deleted != null;
     }
 
     /**


### PR DESCRIPTION
## Ticket

[ENG-1107](https://openscience.atlassian.net/browse/ENG-1107)

## Purpose

For the `addons_twofactor_usersettings` object in OSF, `is_deleted` : `django.db.models.BooleanField` has been deprecated and replaced by `deleted` : `NonNaiveDateTimeField`.

Its counterpart in CAS, property `deleted` and  method `isDeleted()` in `OpenScienceFrameworkTimeBasedOneTimePassword` (OSFTBOTP) need to be updated to reflect this change.

`django.db.models.DateTimeField` is the base class for `osf.utils.fields.NonNaiveDateTimeField`. In Hibernate / JPA, use `javax.persistence.TemporalType.TIMESTAMP`  as the replacement.

Although the check `isDeleted()` only verifies whether the field has been set or not, I still verified locally that the timestamp is correct.

![2FA-Enabled](https://user-images.githubusercontent.com/3750414/77100734-856e0600-69ec-11ea-80e5-d8a69919463a.png)

![2FA-Disabled](https://user-images.githubusercontent.com/3750414/77100737-856e0600-69ec-11ea-8756-1d588b179135.png)

## Changes

See **Purpose** and the diff.

## Dev / QA Notes

### Dev

When testing PR with OSF-side migration, need to perform a pre-and-post testing.

#### Pre-testing

* Checkout the current `develop`, build and run CAS
* Create a bunch of users with 2FA and disable some of them
* Verify that 2FA login is required for enabled and skipped for disabled

#### Post-testing

* Checkout the PR branch, build and run CAS
* Test the previously tested users and make sure that 2FA works
* Enable / Disable 2FA for previously tested users and verify 2FA works

### QA

#### Pre-testing: `develop` on Staging 3

* Create a bunch of users with 2FA and disable some of them
* Verify that 2FA login is required for enabled and skipped for disabled

#### Post-testing: `feature/totp_deleted` on Staging 3

* Test the previously tested users and make sure that 2FA works
* Enable / Disable 2FA for previously tested users and verify 2FA works

## Dev-Ops Notes

- [x] All servers has finished `is_deleted` -> `deleted` population. 
- [x] ~~Don't merge until QA has finished pre-testing preparation.~~ Merge into a branch called `feature/totp_deleted`.