### PR TITLE
[ENG-1592] Institution Department

### DIFF
--- a/cas-server-support-osf/src/main/java/io/cos/cas/authentication/handler/support/OpenScienceFrameworkPrincipalFromRequestRemoteUserNonInteractiveCredentialsAction.java
+++ b/cas-server-support-osf/src/main/java/io/cos/cas/authentication/handler/support/OpenScienceFrameworkPrincipalFromRequestRemoteUserNonInteractiveCredentialsAction.java
@@ -75,6 +75,8 @@ import org.springframework.webflow.execution.RequestContext;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
+import javax.naming.InvalidNameException;
+import javax.naming.ldap.LdapName;
 import javax.security.auth.login.AccountException;
 import javax.security.auth.login.FailedLoginException;
 import javax.servlet.http.Cookie;
@@ -168,6 +170,8 @@ public class OpenScienceFrameworkPrincipalFromRequestRemoteUserNonInteractiveCre
     private static final String SHIBBOLETH_SESSION_HEADER = ATTRIBUTE_PREFIX + "Shib-Session-ID";
 
     private static final String SHIBBOLETH_COOKIE_PREFIX = "_shibsession_";
+
+    private static final String LDAP_DN_OU_PREFIX = "ou=";
 
     private static final int SIXTY_SECONDS = 60 * 1000;
 
@@ -522,6 +526,11 @@ public class OpenScienceFrameworkPrincipalFromRequestRemoteUserNonInteractiveCre
         final String fullname = user.optString("fullname").trim();
         final String givenName = user.optString("givenName").trim();
         final String familyName = user.optString("familyName").trim();
+        final String departmentRaw = user.optString("departmentRaw").trim();
+        // Unlike all the above attributes that are released to us from the institutions, the `eduPerson` is a boolean
+        // per-institution flag set by CAS in the "institutions-auth.xsl" file. It determines whether the department
+        // attribute uses the the eduPerson schema (https://wiki.refeds.org/display/STAN/eduPerson).
+        final boolean eduPerson = user.optBoolean("eduPerson");
         if (username.isEmpty()) {
             logger.error("[CAS XSLT] Missing email (username) for user at institution '{}'", institutionId);
             throw new InstitutionLoginFailedAttributesMissingException("Missing email (username)");
@@ -530,6 +539,15 @@ public class OpenScienceFrameworkPrincipalFromRequestRemoteUserNonInteractiveCre
             logger.error("[CAS XSLT] Missing names: username={}, institution={}", username, institutionId);
             throw new InstitutionLoginFailedAttributesMissingException("Missing user's names");
         }
+        String department = "";
+        if (departmentRaw.isEmpty()) {
+            logger.warn("[CAS XSLT] Missing department: fullname={}, username={}, institution={}", fullname, username, institutionId);
+        } else {
+            department = this.retrieveDepartment(departmentRaw, eduPerson);
+        }
+        // Insert the `department` attribute into the payload, which does not overwrite `departmentRaw`.
+        normalizedPayload.getJSONObject("provider").getJSONObject("user").put("department", department);
+
         final String payload = normalizedPayload.toString();
         logger.info("[CAS XSLT] All attributes checked: username={}, institution={}", username, institutionId);
         logger.debug(
@@ -640,6 +658,42 @@ public class OpenScienceFrameworkPrincipalFromRequestRemoteUserNonInteractiveCre
 
         // convert transformed xml to json
         return XML.toJSONObject(writer.getBuffer().toString());
+    }
+
+    /**
+     * Retrieve the department value from the raw department string.
+     *
+     * @param departmentRaw the raw department string
+     * @param eduPerson whether the department attribute uses eduPerson schema
+     * @return the department value
+     */
+    private String retrieveDepartment(final String departmentRaw, final boolean eduPerson) {
+
+        // Return the raw value as it is if institutions do not use eduPerson schema for the department attribute
+        if (!eduPerson) {
+            return departmentRaw;
+        }
+
+        // For institutions that use the eduPerson schema, the department must be retrieved from the raw value. Here is
+        // an example: "ou=Music Department, o=Notre Dame, dc=nd, dc=edu", whose syntax is LDAP Distinguished Names.
+        try {
+            final LdapName dn = new LdapName(departmentRaw);
+            for (int i = dn.size() - 1; i >=0; i--) {
+                final String rdn = dn.get(i);
+                if (rdn.startsWith(LDAP_DN_OU_PREFIX)) {
+                    return rdn.substring(LDAP_DN_OU_PREFIX.length());
+                }
+            }
+        } catch (final InvalidNameException | IndexOutOfBoundsException e) {
+            logger.error(
+                    "[CAS XSLT] Invalid syntax for LDAP Distinguished Names: departmentRaw={}, error={}",
+                    departmentRaw,
+                    e.getMessage()
+            );
+            // Return an empty string if the syntax is wrong
+            return "";
+        }
+        return "";
     }
 
     public void setInstitutionsAuthUrl(final String institutionsAuthUrl) {

--- a/etc/institutions-auth.xsl
+++ b/etc/institutions-auth.xsl
@@ -36,10 +36,12 @@
                         <id>esu</id>
                         <user>
                             <!--  Each institution has its customized mapping of attributes  -->
-                            <username><xsl:value-of select="//attribute[@name='eppn']/@value"/></username>
+                            <username><xsl:value-of select="//attribute[@name='mail']/@value"/></username>
                             <fullname><xsl:value-of select="//attribute[@name='displayedName']/@value"/></fullname>
                             <familyName><xsl:value-of select="//attribute[@name='sn']/@value"/></familyName>
                             <givenName><xsl:value-of select="//attribute[@name='givenName']/@value"/></givenName>
+                            <departmentRaw><xsl:value-of select="//attribute[@name='department']/@value"/></departmentRaw>
+                            <eduPerson>true</eduPerson>
                             <middleNames/>
                             <suffix/>
                         </user>
@@ -125,6 +127,8 @@
                             <fullname><xsl:value-of select="//attribute[@name='displayName']/@value"/></fullname>
                             <familyName><xsl:value-of select="//attribute[@name='sn']/@value"/></familyName>
                             <givenName><xsl:value-of select="//attribute[@name='givenName']/@value"/></givenName>
+                            <departmentRaw><xsl:value-of select="//attribute[@name='department']/@value"/></departmentRaw>
+                            <eduPerson>false</eduPerson>
                             <middleNames/>
                             <suffix/>
                         </user>


### PR DESCRIPTION
## Ticket

[ENG-1592](https://openscience.atlassian.net/browse/ENG-1592)

## Purpose

Support department attribute in released institutional attributes.

## Changes

The value of the department attribute, unlike others, is schema specific per institution.

Currently CAS supports only one - the eduPerson, which is a LDAP schema where the attribute for department i.e. `eduPersonPrimaryOrgUnitDN` is of the syntax "LDAP Distinguished Names". In this case, CAS uses one RDN `ou=<department_name>` to retrieve the department information.

![eduPerson-schema](https://user-images.githubusercontent.com/3750414/77494582-789e4780-6e1c-11ea-966a-be6cc3853852.png)

For all other cases, CAS uses the raw value.

![non-eduPerson-schema](https://user-images.githubusercontent.com/3750414/77494616-8d7adb00-6e1c-11ea-92cb-3dbbd3f52c86.png)

If the department is not provided, is empty or is of invalid format, CAS set its value to an empty string.

## Dev / QA Notes

OSF side needs this [PR / commit](https://github.com/CenterForOpenScience/osf.io/commit/9b883a570ad588aecec4bf064c21bf15c6f8088f) with migrations.

On the CAS side, update you local `institutions-auth.xsl` by using the following XSLT to mock the department attribute (two types).

### eduPerson Schema (LDAP Distinguished Names)

```xml
<!-- Concordia College (CORD) -->
<xsl:when test="$idp='cord'">
    <id>cord</id>
    <user>
        <username><xsl:value-of select="//attribute[@name='mail']/@value"/></username>
        <fullname><xsl:value-of select="//attribute[@name='displayName']/@value"/></fullname>
        <departmentRaw>ou=Music Department, o=Concordia College, dc=cord, dc=edu</departmentRaw>
        <eduPerson>true</eduPerson>
        <familyName />
        <givenName />
        <middleNames/>
        <suffix/>
    </user>
</xsl:when>
```

### Other

Replace the following two tags in the XSLT above.

```xml
<departmentRaw>Music Department</departmentRaw>
<eduPerson>false</eduPerson>
```

## Dev-Ops Notes

Nothing for now since no institution provides us the attribute for department.

This PR can be merged into `develop` or `master` without affecting current institution login since it simply send an empty department attribute to OSF API which will throw that away.

![backward-compatibility](https://user-images.githubusercontent.com/3750414/77495105-fdd62c00-6e1d-11ea-87a6-cf3ea642efa6.png)

![backward-compatibility-2](https://user-images.githubusercontent.com/3750414/77495493-1e52b600-6e1f-11ea-955f-d9bb00befb6c.png)

