### PR TITLE
[ENG-1589] Institution Auto Selection During Login

### DIFF
--- a/cas-server-support-osf/src/main/java/io/cos/cas/adaptors/postgres/handlers/OpenScienceFrameworkAuthenticationHandler.java
+++ b/cas-server-support-osf/src/main/java/io/cos/cas/adaptors/postgres/handlers/OpenScienceFrameworkAuthenticationHandler.java
@@ -58,7 +58,7 @@ import javax.validation.constraints.NotNull;
  *
  * @author Michael Haselton
  * @author Longze Chen
- * @since 19.0.0
+ * @since 19.3.0
  */
 public class OpenScienceFrameworkAuthenticationHandler extends AbstractPreAndPostProcessingAuthenticationHandler
         implements InitializingBean {

--- a/cas-server-support-osf/src/main/java/io/cos/cas/adaptors/postgres/handlers/OpenScienceFrameworkInstitutionHandler.java
+++ b/cas-server-support-osf/src/main/java/io/cos/cas/adaptors/postgres/handlers/OpenScienceFrameworkInstitutionHandler.java
@@ -19,17 +19,18 @@ import io.cos.cas.adaptors.postgres.daos.OpenScienceFrameworkDaoImpl;
 import io.cos.cas.adaptors.postgres.models.OpenScienceFrameworkInstitution;
 import io.cos.cas.adaptors.postgres.types.DelegationProtocol;
 
-import javax.validation.constraints.NotNull;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
+import javax.validation.constraints.NotNull;
+
 /**
  * The Open Science Framework Institution Handler.
  *
  * @author Longze Chen
- * @since 4.1.5
+ * @since 19.3.0
  */
 public class OpenScienceFrameworkInstitutionHandler {
 

--- a/cas-server-support-osf/src/main/java/io/cos/cas/adaptors/postgres/handlers/OpenScienceFrameworkInstitutionHandler.java
+++ b/cas-server-support-osf/src/main/java/io/cos/cas/adaptors/postgres/handlers/OpenScienceFrameworkInstitutionHandler.java
@@ -21,6 +21,7 @@ import io.cos.cas.adaptors.postgres.types.DelegationProtocol;
 
 import javax.validation.constraints.NotNull;
 import java.util.HashMap;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
@@ -46,9 +47,22 @@ public class OpenScienceFrameworkInstitutionHandler {
     }
 
     /**
+     * Check if an institution of a given ID exists and supports SSO.
+     *
+     * @param id the OSF institution ID that identifies the institution
+     * @return <code>true</code> if exists and <code>false </code> otherwise
+     */
+    public boolean validateInstitutionForLogin(final String id) {
+
+        final OpenScienceFrameworkInstitution institution
+                = openScienceFrameworkDao.findOneInstitutionById(id);
+        return institution != null && institution.getDelegationProtocol() != null;
+    }
+
+    /**
      * Find the logout url for given institution identified by institution _id.
      *
-     * @param id the institution _id
+     * @param id the OSF institution ID that identifies the institution
      * @return String or null
      */
     public String findInstitutionLogoutUrlById(final String id) {
@@ -57,52 +71,41 @@ public class OpenScienceFrameworkInstitutionHandler {
     }
 
     /**
-     * <p>Return a map of institution login url or institution ID as key and institution name as value for the
-     * specified institution.</p>
-     *
-     * @param target the osf service target after successful institution login, only used for "saml-shib" institutions
-     * @param institutionId the OSF institution ID that identifies the institution
-     * @return a single-entry {@link Map} if institution is found or <code>null</code> otherwise. For "saml-shib"
-     *         institutions, full login url as key and full institution display name as value; for "cas-pac4j" ones,
-     *         institution id as key and full institution display name as value.
-     */
-    public Map<String, String> getInstitutionLoginUrls(final String target, final String institutionId) {
-        final OpenScienceFrameworkInstitution institution
-                = openScienceFrameworkDao.findOneInstitutionById(institutionId);
-        if (institution == null) {
-            return null;
-        }
-        final Map<String, String> institutionLogin = new HashMap<>();
-        final DelegationProtocol delegationProtocol = institution.getDelegationProtocol();
-        if (DelegationProtocol.SAML_SHIB.equals(delegationProtocol)) {
-            institutionLogin.put(institution.getLoginUrl() + "&target=" + target, institution.getName());
-        } else if (DelegationProtocol.CAS_PAC4J.equals(delegationProtocol)) {
-            institutionLogin.put(institution.getId(), institution.getName());
-        } else {
-            return null;
-        }
-        return institutionLogin;
-    }
-
-    /**
      * <p>Return a map of institution login url or institution ID as key and institution name as value.</p>
      *
+     * <p>For saml-shib institutions, the login url is the key and the institution display name is the value.</p>
+     *
+     * <p>For cas-pac4j institutions, the institution ID is the key and the institution display name is the value. </p>
+     *
      * @param target the osf service target after successful institution login, only used for "saml-shib" institutions
-     * @return a multi-entry {@link Map}. For "saml-shib" institutions, full login url as key and full institution
-     *         display name as value; for "cas-pac4j" ones, institution id as key and full institution display name as
-     *         value.
+     * @param id the OSF institution ID if auto-selection is enabled
+     * @return a single-entry {@link Map} if <code>id</code> presents and if the institution this <code>id</code>
+     *         identifies exists and supports institution SSO; otherwise return a multi-entry {@link Map} of all.
      */
-    public Map<String, String> getInstitutionLoginUrls(final String target) {
-        final List<OpenScienceFrameworkInstitution> institutionList = openScienceFrameworkDao.findAllInstitutions();
-        final Map<String, String> institutionLogin = new HashMap<>();
+    public Map<String, String> getInstitutionLoginUrlMap(final String target, final String id) {
+
+        List<OpenScienceFrameworkInstitution> institutionList = new LinkedList<>();
+        if (id == null || id.isEmpty()) {
+            institutionList = openScienceFrameworkDao.findAllInstitutions();
+        } else {
+            final OpenScienceFrameworkInstitution institution
+                    = openScienceFrameworkDao.findOneInstitutionById(id);
+            if (institution != null) {
+                institutionList.add(institution);
+            } else {
+                institutionList = openScienceFrameworkDao.findAllInstitutions();
+            }
+        }
+
+        final Map<String, String> institutionLoginUrlMap = new HashMap<>();
         for (final OpenScienceFrameworkInstitution institution: institutionList) {
             final DelegationProtocol delegationProtocol = institution.getDelegationProtocol();
             if (DelegationProtocol.SAML_SHIB.equals(delegationProtocol)) {
-                institutionLogin.put(institution.getLoginUrl() + "&target=" + target, institution.getName());
+                institutionLoginUrlMap.put(institution.getLoginUrl() + "&target=" + target, institution.getName());
             } else if (DelegationProtocol.CAS_PAC4J.equals(delegationProtocol)) {
-                institutionLogin.put(institution.getId(), institution.getName());
+                institutionLoginUrlMap.put(institution.getId(), institution.getName());
             }
         }
-        return institutionLogin;
+        return institutionLoginUrlMap;
     }
 }

--- a/cas-server-support-osf/src/main/java/io/cos/cas/adaptors/postgres/models/OpenScienceFrameworkUser.java
+++ b/cas-server-support-osf/src/main/java/io/cos/cas/adaptors/postgres/models/OpenScienceFrameworkUser.java
@@ -38,7 +38,7 @@ import javax.persistence.TemporalType;
  *
  * @author Michael Haselton
  * @author Longze Chen
- * @since 19.0.0
+ * @since 19.3.0
  */
 @Entity
 @Table(name = "osf_osfuser")

--- a/cas-server-support-osf/src/main/java/io/cos/cas/web/flow/OpenScienceFrameworkAuthenticationExceptionHandler.java
+++ b/cas-server-support-osf/src/main/java/io/cos/cas/web/flow/OpenScienceFrameworkAuthenticationExceptionHandler.java
@@ -55,7 +55,7 @@ import javax.security.auth.login.FailedLoginException;
  *
  * @author Michael Haselton
  * @author Longze Chen
- * @since 19.0.0
+ * @since 19.3.0
  */
 public class OpenScienceFrameworkAuthenticationExceptionHandler extends AuthenticationExceptionHandler {
 

--- a/cas-server-support-osf/src/main/java/io/cos/cas/web/flow/OpenScienceFrameworkInstitutionLoginHandler.java
+++ b/cas-server-support-osf/src/main/java/io/cos/cas/web/flow/OpenScienceFrameworkInstitutionLoginHandler.java
@@ -81,6 +81,11 @@ public class OpenScienceFrameworkInstitutionLoginHandler {
         Map<String, String> sortedInstitutions = null;
         if (institutionId != null) {
             sortedInstitutions = this.institutionHandler.getInstitutionLoginUrls(target, institutionId);
+            // Set institution ID to null if not found
+            if (sortedInstitutions == null) {
+                osfLoginContext.setInstitutionId(null);
+                context.getFlowScope().put("jsonLoginContext", osfLoginContext.toJson());
+            }
         }
 
         // All institutions if auto selection is disabled or if auto selection is invalid

--- a/cas-server-support-osf/src/main/java/io/cos/cas/web/flow/OpenScienceFrameworkInstitutionLoginHandler.java
+++ b/cas-server-support-osf/src/main/java/io/cos/cas/web/flow/OpenScienceFrameworkInstitutionLoginHandler.java
@@ -33,7 +33,7 @@ import java.util.Map;
  * Open Science Framework Institution Login Handler.
  *
  * @author Longze Chen
- * @since 4.1.5
+ * @since 19.3.0
  */
 public class OpenScienceFrameworkInstitutionLoginHandler {
 

--- a/cas-server-support-osf/src/main/java/io/cos/cas/web/flow/OpenScienceFrameworkLoginHandler.java
+++ b/cas-server-support-osf/src/main/java/io/cos/cas/web/flow/OpenScienceFrameworkLoginHandler.java
@@ -27,7 +27,7 @@ import java.net.URLEncoder;
  * Open Science Framework Login Handler.
  *
  * @author Longze Chen
- * @since 4.1.5
+ * @since 19.3.0
  */
 public class OpenScienceFrameworkLoginHandler {
 

--- a/cas-server-support-osf/src/main/java/io/cos/cas/web/flow/OpenScienceFrameworkLoginHandler.java
+++ b/cas-server-support-osf/src/main/java/io/cos/cas/web/flow/OpenScienceFrameworkLoginHandler.java
@@ -101,7 +101,8 @@ public class OpenScienceFrameworkLoginHandler {
             this.institutionLogin = institutionLogin;
         }
 
-        String getInstitutionId() {
+        // Must be public to be accessible in the JSP page
+        public String getInstitutionId() {
             return institutionId;
         }
 

--- a/cas-server-support-osf/src/main/java/io/cos/cas/web/flow/OpenScienceFrameworkLoginHandler.java
+++ b/cas-server-support-osf/src/main/java/io/cos/cas/web/flow/OpenScienceFrameworkLoginHandler.java
@@ -158,10 +158,10 @@ public class OpenScienceFrameworkLoginHandler {
     public Event beforeLogin(final RequestContext context) {
 
         final OpenScienceFrameworkLoginContext osfLoginContext;
-        final String serviceUrl = getEncodedServiceUrl(context);
+        final String serviceUrl = getEncodedServiceUrlFromRequestContext(context);
         final boolean institutionLogin = isInstitutionLogin(context);
-        final String institutionId = getInstitutionId(context);
-        final boolean orcidRedirect = isOrcidRedirect(context);
+        final String institutionId = getInstitutionIdFromRequestContext(context);
+        final boolean orcidRedirect = checkOrcidRedirectFromRequestContext(context);
 
         String jsonLoginContext = (String) context.getFlowScope().get("jsonLoginContext");
         if (jsonLoginContext == null) {
@@ -215,7 +215,7 @@ public class OpenScienceFrameworkLoginHandler {
      * @param context the request context
      * @return the institution ID
      */
-    private String getInstitutionId(final RequestContext context) {
+    private String getInstitutionIdFromRequestContext(final RequestContext context) {
         final String institutionId = context.getRequestParameters().get("institutionId");
         return (institutionId == null || institutionId.isEmpty()) ? null : institutionId;
     }
@@ -226,7 +226,7 @@ public class OpenScienceFrameworkLoginHandler {
      * @param context the request context
      * @return true if `redirectOrcid=true` is present in the request parameters
      */
-    private boolean isOrcidRedirect(final RequestContext context) {
+    private boolean checkOrcidRedirectFromRequestContext(final RequestContext context) {
         final String orcidRedirect = context.getRequestParameters().get("redirectOrcid");
         return orcidRedirect != null && "true".equals(orcidRedirect.toLowerCase());
     }
@@ -241,7 +241,7 @@ public class OpenScienceFrameworkLoginHandler {
      * @return the encoded service url
      * @throws AssertionError if encoding fails
      */
-    private String getEncodedServiceUrl(final RequestContext context) throws AssertionError {
+    private String getEncodedServiceUrlFromRequestContext(final RequestContext context) throws AssertionError {
         final String serviceUrl = context.getRequestParameters().get("service");
         if (serviceUrl == null || serviceUrl.isEmpty()) {
             return null;

--- a/cas-server-webapp/src/main/resources/messages.properties
+++ b/cas-server-webapp/src/main/resources/messages.properties
@@ -179,6 +179,8 @@ screen.unavailable.message=There was an error trying to complete your request.  
 # Institution
 screen.institution.login.heading=Sign in through institution
 screen.institution.login.select=Select your institution
+screen.institution.login.select.auto=Your institution
+screen.institution.login.select.all=Not your institution?
 screen.institution.login.message=If your institution has partnered with OSF, please select its name below and sign in with your institutional credentials.<br/><br/>If you do not currently have an OSF account, this will create one for you.
 screen.institution.login.osf=Log in with OSF
 screen.institution.login.consent.checkbox=I have read and agree to the <a style="white-space: nowrap" href=https://github.com/CenterForOpenScience/centerforopenscience.org/blob/master/TERMS_OF_USE.md>Terms of Use</a> and <a style="white-space: nowrap" href=https://github.com/CenterForOpenScience/centerforopenscience.org/blob/master/PRIVACY_POLICY.md>Privacy Policy</a>.

--- a/cas-server-webapp/src/main/webapp/WEB-INF/view/jsp/default/ui/casInstitutionLoginView.jsp
+++ b/cas-server-webapp/src/main/webapp/WEB-INF/view/jsp/default/ui/casInstitutionLoginView.jsp
@@ -22,6 +22,8 @@
 
 <div id="inst-login">
 
+    <c:set var="serviceParam" value="&service=${osfLoginContext.isServiceUrl() ? osfLoginContext.getServiceUrl() : ''}"/>
+
     <script>resizeCasContent();</script>
 
     <section class="row">
@@ -30,16 +32,38 @@
         </div>
     </section><br/>
 
-    <section class="row">
-        <div class="select">
-            <label for="select-institution"><spring:message code="screen.institution.login.select" /></label>
-        </div>
-    </section>
-    <section class="row">
-        <div class="select">
-            <form:select class="select" id="institution-form-select" name="select-institution" path="institutions" items="${institutions}" onchange="checkSelect()" autofocus="autofocus"/>
-        </div>
-    </section><br/>
+    <c:choose>
+        <c:when test="${osfLoginContext.getInstitutionId() != null}">
+            <section class="row">
+                <div class="select">
+                    <label for="select-institution"><spring:message code="screen.institution.login.select.auto" /></label>
+                </div>
+            </section>
+            <section class="row">
+                <div class="select">
+                    <form:select class="select" id="institution-form-select" name="select-institution" path="institutions" items="${institutions}" onchange="checkSelect()" autofocus="autofocus" disabled="true"/>
+                </div>
+            </section>
+            <spring:eval var="defaultInstitutionLoginURL" expression="@casProperties.getProperty('cas.institution.login.url')"/>
+            <a id="not-your-institution" class='need-help' href="${defaultInstitutionLoginURL}${serviceParam}"><spring:message code="screen.institution.login.select.all"/></a>
+            <br/>
+            <c:set var="institutionIdParam" value="&institutionId=${osfLoginContext.getInstitutionId()}"/>
+        </c:when>
+        <c:otherwise>
+            <section class="row">
+                <div class="select">
+                    <label for="select-institution"><spring:message code="screen.institution.login.select" /></label>
+                </div>
+            </section>
+            <section class="row">
+                <div class="select">
+                    <form:select class="select" id="institution-form-select" name="select-institution" path="institutions" items="${institutions}" onchange="checkSelect()" autofocus="autofocus" disabled="false"/>
+                </div>
+            </section>
+            <c:set var="institutionIdParam" value="&institutionId="/>
+        </c:otherwise>
+    </c:choose>
+    <br/>
 
     <section class="row">
         <div class="inst-message">
@@ -64,9 +88,8 @@
     <%-- OSF Username and Password Login --%>
     <hr/><br/>
     <spring:eval var="osfLoginUrl" expression="@casProperties.getProperty('cas.osf.login.url')"/>
-    <c:set var="serviceParam" value="&service=${osfLoginContext.isServiceUrl() ? osfLoginContext.getServiceUrl() : ''}"/>
     <section class="row">
-        <a id="alt-login-osf" class="btn-alt-login" href="${osfLoginUrl}${serviceParam}">
+        <a id="alt-login-osf" class="btn-alt-login" href="${osfLoginUrl}${serviceParam}${institutionIdParam}">
             <img class="osf-alt-logo" src="../images/osf-logo.png">
             <span class="label-login"><spring:message code="screen.institution.login.osf"/></span>
         </a>

--- a/cas-server-webapp/src/main/webapp/WEB-INF/view/jsp/default/ui/casLoginView.jsp
+++ b/cas-server-webapp/src/main/webapp/WEB-INF/view/jsp/default/ui/casLoginView.jsp
@@ -80,8 +80,9 @@
         <%-- Institution Login --%>
         <spring:eval var="institutionLoginUrl" expression="@casProperties.getProperty('cas.institution.login.url')"/>
         <c:set var="serviceParam" value="&service=${osfLoginContext.isServiceUrl() ? osfLoginContext.getServiceUrl() : ''}"/>
+        <c:set var="institutionIdParam" value="&institutionId=${osfLoginContext.getInstitutionId()}"/>
         <section class="row">
-            <a id="alt-login-inst" class="btn-alt-login" href="${institutionLoginUrl}${serviceParam}">
+            <a id="alt-login-inst" class="btn-alt-login" href="${institutionLoginUrl}${serviceParam}${institutionIdParam}">
                 <img class="osf-alt-logo" src="../images/institution-logo.png">
                 <span class="label-login"><spring:message code="screen.welcome.button.login.institution"/></span>
             </a>
@@ -122,7 +123,7 @@
             <input type="checkbox" name="rememberMe" id="rememberMe" value="true" checked tabindex="5"/>
             <label for="rememberMe"><spring:message code="screen.rememberme.checkbox.title"/></label>
             <spring:eval var="forgotPasswordUrl" expression="@casProperties.getProperty('osf.forgotPassword.url')"/>
-            <a id="forgot-password" class='need-help' href="${forgotPasswordUrl}" title="<spring:message code="logo.title" />"><spring:message code="screen.general.link.forgotPassword"/></a>
+            <a id="forgot-password" class='need-help' href="${forgotPasswordUrl}"><spring:message code="screen.general.link.forgotPassword"/></a>
         </section>
 
     </form:form>

--- a/cas-server-webapp/src/main/webapp/css/cas.css
+++ b/cas-server-webapp/src/main/webapp/css/cas.css
@@ -454,6 +454,10 @@ footer a:link, footer a:visited {
     width: 100%;
 }
 
+#inst-login .need-help {
+    font-size: 15px;
+}
+
 #inst-login .btn-submit input[type=button],
 #fm1 .row .btn-submit {
     outline: none;


### PR DESCRIPTION
## Ticket

[ENG-1589](https://openscience.atlassian.net/browse/ENG-1589)

## Purpose

Support pre-selecting an institution during institution login if the parameter `institutionId=<OSF Institution ID>` is provided.

```
https://accounts.test.osf.io/login?campaign=institution&institutionId=cord&service=http%3A%2F%2Flocalhost%3A5000%2Flogin%2F%3Fnext%3Dhttp%253A%252F%252Flocalhost%253A5000%252F
```

Currently, there are two types of user cases requested that are now supported **on the OSF CAS end**.

* Applications / Services at the institution end can provide a direct URL to the institution login page instead of going through OSF.
  * Need to inform institutions after release with a new login URL for them to take advantage of this feature.

* When users start from their OSF institution page, the login should bring them to the institution login page directly with the institution selected.
  * Need another front-end ticket to generate correct OSF CAS institution login URL with the new query parameter to enable this feature.

## Changes

* Updated both OSF login handler and institution login handler to handle the extra URL query parameter "institutionId" for auto selecting institutions.

* Added a new method to retrieve only one institution in Postgres adapters for OSF institution model. This not only saves extra backend and DB operations but avoids clumsy frontend scripting as well.

* As for the auto-select feature when switching between OSF login and institution login pages, valid institution ID is preserved while invalid institution ID is removed.

* In auto-select mode, the heading says "Your institution" instead of "Select your institution"; the dropdown list for selection is disabled; and a help link with text "Not your institution?" is added below if user wants to select another institution.

![auto-select-institution](https://user-images.githubusercontent.com/3750414/79789933-f7ea4280-8318-11ea-9723-b7bff83ccd33.png)

## Side Effect

* If an invalid institution ID is provided, OSF CAS ignores it and follows the default institution login path (all institutions with selection enabled).

## Dev / QA Notes

### Getting Started

This new "auto-inst-select" page can only be reached via crafting the URL manually since OSF is yet to take advantage of this feature.

Here is the default URL

> https://accounts.staging3.osf.io/login?campaign=institution&service=https%3A%2F%2Fstaging3.osf.io%2Flogin%2F%3Fnext%3Dhttps%253A%252F%252Fstaging3.osf.io%252F&institutionId=

To reach the new page, add a query parameter `institutionId=<institution id>`. [Here](https://github.com/CenterForOpenScience/osf.io/blob/develop/scripts/populate_institutions.py) is where to find the institution ID for a given institution. (Sometimes the query is there with empty value, just need to add the ID.

### Testing

* Empty or none `institutionId=`
  * Go to staging 3 OSF
  * Click "Sign In" -> CAS default login page
  * Click "Sign in through institution", users should land on the normal institution login page with ability to select their institutions.

* Valid `institutionId=`
  * Go to the page with the manually crafted URL
  * Check "Your institution" is there instead of "Select your institution"
  * Check that the selection box has the correct institution
  * Check that the selection box is greyed out (a.k.a disabled)
  * Click "Login with OSF" and then click "Sign in through institution", users still have the previous institution selected. The only way to get out of it is by clicking "Not your institution?"
  * Click "Not your institution?" brings users back to the normal institution login page

<img width="941" alt="cas-auto-inst-select-qa-1" src="https://user-images.githubusercontent.com/3750414/82594631-63227100-9b72-11ea-9aed-05bfe74fc001.png">

* Invalid `institutionId=`
  * When you provide an invalid institution ID to the query param, CAS should act as if none or empty value were provided.

* Extra
  * Does the pages looks good?
  * Does the language reads OK?
  * Is there anything confusing or too complicated?

## Dev-Ops Notes

N / A
