### PR TITLE
[Institution SSO] [ENG-2005] Ignore multi-value attributes gracefully for cas-pac4j based Institution SSO

### DIFF
--- a/cas-server-support-osf/src/main/java/io/cos/cas/authentication/handler/support/OpenScienceFrameworkPrincipalFromRequestRemoteUserNonInteractiveCredentialsAction.java
+++ b/cas-server-support-osf/src/main/java/io/cos/cas/authentication/handler/support/OpenScienceFrameworkPrincipalFromRequestRemoteUserNonInteractiveCredentialsAction.java
@@ -455,6 +455,9 @@ public class OpenScienceFrameworkPrincipalFromRequestRemoteUserNonInteractiveCre
                             entry.getKey(),
                             entry.getValue()
                     );
+                    // As for the CAS protocol with SAML validation, the attributes we need (a.k.a email and names) are
+                    // expected to be of the type `String` when they are parsed from the SAML response XML and stored in
+                    // the `attribute` map of the `Principal` object.
                     if (entry.getValue() instanceof String) {
                         logger.info(
                                 "[CAS PAC4J] Delegation attribute map updated: '{}', '{}', '{}', '{}'",
@@ -463,10 +466,12 @@ public class OpenScienceFrameworkPrincipalFromRequestRemoteUserNonInteractiveCre
                                 entry.getKey(),
                                 entry.getValue()
                         );
-                        credential.getDelegationAttributes().put(entry.getKey(), (String) entry.getValue());
+                        credential.getDelegationAttributes().put(entry.getKey(), String.valueOf(entry.getValue()));
                     } else if (entry.getValue() instanceof ArrayList) {
+                        // CAS doesn't support multi-value attributes. Don't store them in the delegation attribute map.
+                        // Use error level logging to inform Sentry
                         logger.error(
-                                "[CAS PAC4J] Multi-value attribute is not supported: '{}', '{}', '{}', '{}', '{}'",
+                                "[CAS PAC4J] Multi-value attribute detected: '{}', '{}', '{}', '{}', '{}'",
                                 clientName,
                                 principal.getId(),
                                 entry.getKey(),
@@ -474,14 +479,16 @@ public class OpenScienceFrameworkPrincipalFromRequestRemoteUserNonInteractiveCre
                                 entry.getValue().getClass().getName()
                         );
                     } else {
+                        // CAS does not expect other value types such as `Integer`, `Boolean`, etc. Don't store them in
+                        // the delegation attribute map.
+                        // Use error level logging to inform Sentry
                         logger.error(
-                                "[CAS PAC4J] Attribute with value of unexpected type: '{}', '{}', '{}', '{}', '{}'",
+                                "[CAS PAC4J] Attribute w/ value of other types detected: '{}', '{}', '{}', '{}', '{}'",
                                 clientName,
                                 principal.getId(),
                                 entry.getKey(),
                                 entry.getValue(),
                                 entry.getValue().getClass().getName()
-
                         );
                     }
                 }

--- a/cas-server-support-osf/src/main/java/io/cos/cas/authentication/handler/support/OpenScienceFrameworkPrincipalFromRequestRemoteUserNonInteractiveCredentialsAction.java
+++ b/cas-server-support-osf/src/main/java/io/cos/cas/authentication/handler/support/OpenScienceFrameworkPrincipalFromRequestRemoteUserNonInteractiveCredentialsAction.java
@@ -94,6 +94,7 @@ import javax.xml.transform.stream.StreamSource;
 import java.io.File;
 import java.io.IOException;
 import java.io.StringWriter;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
 import java.util.LinkedHashMap;
@@ -442,12 +443,41 @@ public class OpenScienceFrameworkPrincipalFromRequestRemoteUserNonInteractiveCre
             if (principal.getAttributes().size() > 0) {
                 for (final Map.Entry<String, Object> entry : principal.getAttributes().entrySet()) {
                     logger.debug(
-                            "[CAS PAC4J] User's institutional identity '{}' - auth header '{}': '{}'",
+                            "[CAS PAC4J] User's institutional identity '{}': '{}' with attribute '{}': '{}'",
+                            clientName,
                             principal.getId(),
                             entry.getKey(),
                             entry.getValue()
                     );
-                    credential.getDelegationAttributes().put(entry.getKey(), (String) entry.getValue());
+                    if (entry.getValue() instanceof String) {
+                        logger.info(
+                                "[CAS PAC4J] Delegation attribute map updated: '{}', '{}', '{}', '{}'",
+                                clientName,
+                                principal.getId(),
+                                entry.getKey(),
+                                entry.getValue()
+                        );
+                        credential.getDelegationAttributes().put(entry.getKey(), (String) entry.getValue());
+                    } else if (entry.getValue() instanceof ArrayList) {
+                        logger.error(
+                                "[CAS PAC4J] Multi-value attribute is not supported: '{}', '{}', '{}', '{}', '{}'",
+                                clientName,
+                                principal.getId(),
+                                entry.getKey(),
+                                entry.getValue(),
+                                entry.getValue().getClass().getName()
+                        );
+                    } else {
+                        logger.error(
+                                "[CAS PAC4J] Attribute with value of unexpected type: '{}', '{}', '{}', '{}', '{}'",
+                                clientName,
+                                principal.getId(),
+                                entry.getKey(),
+                                entry.getValue(),
+                                entry.getValue().getClass().getName()
+
+                        );
+                    }
                 }
             } else {
                 // CAS IdP servers must provide required attributes such as user's email and full name.


### PR DESCRIPTION
## Ticket

https://openscience.atlassian.net/browse/ENG-2005

## Purpose

OKState recently updated their SSO by adding multi-factor authentication. This resulted in some of the single-value attributes are now multi-value, which ended up breaking the SSO. This PR fix the issue on our side to ignore multi-value attributes gracefully.

## Changes

* Multi-value attributes broke institution SSO when they are added to the delegation attributes map. The map expects `String` as the value but multi-value ones are of type `ArrayList`. Type cast error is thrown in this case. This commit ignores such attributes with error level logs to inform sentry. As long as `uid`, `mail`, `giveName` and `sn` are single-value, SSO can proceed w/o a problem.

* In addition, logging has been improved to include more information such as the `clientName` (which institution) and `principalID` (which user).

* Finally, double check `clientName` for `pac4j` auth with extra logs and removed related TODO list. See comments in the code for details.

## Dev / QA Notes

Locally verified with using the ORCiD client to impersonal CAS client with minor flow tweak and attribute modification since we don't have any institution account and we ORCiD doesn't provide multi-value attributes. All three (`String`, `ArralyList` and other types) are handled as expected.

```
INFO  [<class name omitted>] - <[PAC4J Delegation] Auth client: OrcidClient w/ principal ID: OrcidProfile#****-****-****-****>
DEBUG [<class name omitted>] - <[CAS PAC4J] User's institutional identity 'OrcidClient': 'OrcidProfile#****-****-****-****' with attribute 'common:uri': 'http://orcid.org/****-****-****-****'>
INFO  [<class name omitted>] - <[CAS PAC4J] Delegation attribute map updated: 'OrcidClient', 'OrcidProfile#****-****-****-****', 'common:uri', 'http://orcid.org/****-****-****-****'>
DEBUG [<class name omitted>] - <[CAS PAC4J] User's institutional identity 'OrcidClient': 'OrcidProfile#****-****-****-****' with attribute 'history:claimed': 'true'>
ERROR [<class name omitted>] - <[CAS PAC4J] Attribute w/ value of other types detected: 'OrcidClient', 'OrcidProfile#****-****-****-****', 'history:claimed', 'true', 'java.lang.Boolean'>
DEBUG [<class name omitted>] - <[CAS PAC4J] User's institutional identity 'OrcidClient': 'OrcidProfile#****-****-****-****' with attribute 'MultiValueAttrName': '[value1, value2, value3]'>
ERROR [<class name omitted>] - <[CAS PAC4J] Multi-value attribute detected: 'OrcidClient', 'OrcidProfile#****-****-****-****', 'MultiValueAttrName', '[value1, value2, value3]', 'java.util.ArrayList'>
DEBUG [<class name omitted>] - <[CAS PAC4J] User's institutional identity 'OrcidClient': 'OrcidProfile#****-****-****-****' with attribute 'history:creation-method': 'Direct'>
INFO  [<class name omitted>] - <[CAS PAC4J] Delegation attribute map updated: 'OrcidClient', 'OrcidProfile#****-****-****-****', 'history:creation-method', 'Direct'>
DEBUG [<class name omitted>] - <[CAS PAC4J] User's institutional identity 'OrcidClient': 'OrcidProfile#****-****-****-****' with attribute 'preferences:locale': 'en'>
ERROR [<class name omitted>] - <[CAS PAC4J] Attribute w/ value of other types detected: 'OrcidClient', 'OrcidProfile#****-****-****-****', 'preferences:locale', 'en', 'java.util.Locale'>
DEBUG [<class name omitted>] - <[CAS PAC4J] User's institutional identity 'OrcidClient': 'OrcidProfile#****-****-****-****' with attribute 'common:path': '****-****-****-****'>
INFO  [<class name omitted>] - <[CAS PAC4J] Delegation attribute map updated: 'OrcidClient', 'OrcidProfile#****-****-****-****', 'common:path', '****-****-****-****'>
```

## Dev-Ops Notes

Hot-fix to test server first. Ask institutions to verify login before release to prod.
