### PR TITLE
[ENG-2171] Fix ORCID login failure due to read timeout

### DIFF
--- a/cas-server-support-osf/src/main/java/org/jasig/cas/support/pac4j/web/flow/ClientAction.java
+++ b/cas-server-support-osf/src/main/java/org/jasig/cas/support/pac4j/web/flow/ClientAction.java
@@ -269,6 +269,14 @@ public final class ClientAction extends AbstractAction {
             final BaseClient baseClient = (BaseClient) client;
             final String redirectionUrl = baseClient.getRedirectionUrl(webContext);
             logger.debug("{} -> {}", key, redirectionUrl);
+            if (client instanceof OrcidClient) {
+                logger.debug(
+                        "{} network timeouts (ms): connection={}, read={}",
+                        client.getName(),
+                        ((OrcidClient) client).getConnectTimeout(),
+                        ((OrcidClient) client).getReadTimeout()
+                );
+            }
             context.getFlowScope().put(key, redirectionUrl);
         }
     }

--- a/cas-server-support-osf/src/main/java/org/pac4j/oauth/client/OrcidClient.java
+++ b/cas-server-support-osf/src/main/java/org/pac4j/oauth/client/OrcidClient.java
@@ -73,13 +73,27 @@ public class OrcidClient extends BaseOAuth20Client<OrcidProfile> {
     /**
      * Instantiate a new {@link OrcidClient}.
      *
-     * @param key the key
-     * @param secret the secret
+     * @param key the client key
+     * @param secret the client secret
+     * @param connectTimeout the timeout for connection
+     * @param readTimeout the timeout for read
+     */
+    public OrcidClient(final String key, final String secret, final int connectTimeout, final int readTimeout) {
+        this(key, secret);
+        setConnectTimeout(connectTimeout);
+        setReadTimeout(readTimeout);
+    }
+
+    /**
+     * Instantiate a new {@link OrcidClient}.
+     *
+     * @param key the client key
+     * @param secret the client secret
      */
     public OrcidClient(final String key, final String secret) {
+        this();
         setKey(key);
         setSecret(secret);
-        setTokenAsHeader(true);
     }
 
     /**

--- a/cas-server-webapp/src/main/webapp/WEB-INF/spring-configuration/authenticationDelegation.xml
+++ b/cas-server-webapp/src/main/webapp/WEB-INF/spring-configuration/authenticationDelegation.xml
@@ -30,6 +30,8 @@
         <property name="secret" value="${oauth.orcid.client.secret}" />
         <property name="scope" value="${oauth.orcid.scope}" />
         <property name="member" value="${oauth.orcid.member}" />
+        <property name="connectTimeout" value="${oauth.orcid.connect.timeout}"/>
+        <property name="readTimeout" value="${oauth.orcid.read.timeout}"/>
     </bean>
 
     <!-- CAS Clients -->

--- a/etc/cas.properties
+++ b/etc/cas.properties
@@ -80,6 +80,8 @@ oauth.orcid.client.id=osf_orcid_developer_app_client_id
 oauth.orcid.client.secret=osf_orcid_developer_app_client_secret
 oauth.orcid.member=false
 oauth.orcid.scope=/authenticate
+oauth.orcid.connect.timeout=10000
+oauth.orcid.read.timeout=60000
 
 ##
 # OSF URLs


### PR DESCRIPTION
## Ticket

https://openscience.atlassian.net/browse/ENG-2171

## Purpose

Fix ORCID login failure due to read timeout when retrieving user profile.

> ORCID login fails consistently for a few users due to their large profile requiring 5-10 seconds to download while the default read timeout for OAuth based clients is only 2. 


## Changes

* Increase the read timeout to 1 min

### Side effects

* Increase the connection timeout (for HTTP handshake) from 0.5 second to 10 seconds
* Improve constructors (does not affect bean init)
* Add debug-level logs for the timeout settings during init

## Dev / QA Notes

N / A

## Dev-Ops Notes

Update `cas.properties` via https://github.com/CenterForOpenScience/helm-charts/pull/60

```
oauth.orcid.connect.timeout=10000
oauth.orcid.read.timeout=60000
```
