### PR TITLE
[ENG-1429] [OSF Institutions] Shared SSO and The Policy Lab

### DIFF
--- a/cas-server-support-osf/src/main/java/io/cos/cas/authentication/handler/support/OpenScienceFrameworkPrincipalFromRequestRemoteUserNonInteractiveCredentialsAction.java
+++ b/cas-server-support-osf/src/main/java/io/cos/cas/authentication/handler/support/OpenScienceFrameworkPrincipalFromRequestRemoteUserNonInteractiveCredentialsAction.java
@@ -565,6 +565,7 @@ public class OpenScienceFrameworkPrincipalFromRequestRemoteUserNonInteractiveCre
         final String fullname = user.optString("fullname").trim();
         final String givenName = user.optString("givenName").trim();
         final String familyName = user.optString("familyName").trim();
+        final String isMemberOf = user.optString("isMemberOf").trim();
         if (username.isEmpty()) {
             logger.error("[CAS XSLT] Missing email (username) for user at institution '{}'", institutionId);
             throw new InstitutionLoginFailedAttributesMissingException("Missing email (username)");
@@ -573,12 +574,25 @@ public class OpenScienceFrameworkPrincipalFromRequestRemoteUserNonInteractiveCre
             logger.error("[CAS XSLT] Missing names: username={}, institution={}", username, institutionId);
             throw new InstitutionLoginFailedAttributesMissingException("Missing user's names");
         }
+        if (!isMemberOf.isEmpty()) {
+            logger.info(
+                    "[CAS XSLT] Secondary institution detected. SSO is '{}' and member is '{}'",
+                    institutionId,
+                    isMemberOf
+            );
+        }
         final String payload = normalizedPayload.toString();
-        logger.info("[CAS XSLT] All attributes checked: username={}, institution={}", username, institutionId);
-        logger.debug(
-                "[CAS XSLT] All attributes checked: username={}, institution={}, normalizedPayload={}",
+        logger.info(
+                "[CAS XSLT] All attributes checked: username={}, institution={}, member={}",
                 username,
                 institutionId,
+                isMemberOf
+        );
+        logger.debug(
+                "[CAS XSLT] All attributes checked: username={}, institution={}, member={}, normalizedPayload={}",
+                username,
+                institutionId,
+                isMemberOf,
                 payload
         );
 

--- a/etc/institutions-auth.xsl
+++ b/etc/institutions-auth.xsl
@@ -57,6 +57,18 @@
                             <suffix/>
                         </user>
                     </xsl:when>
+                    <!-- Brown University (BROWN) -->
+                    <xsl:when test="$idp='https://sso.brown.edu/idp/shibboleth'">
+                        <id>brown</id>
+                        <user>
+                            <username><xsl:value-of select="//attribute[@name='mail']/@value"/></username>
+                            <fullname><xsl:value-of select="//attribute[@name='displayName']/@value"/></fullname>
+                            <familyName><xsl:value-of select="//attribute[@name='sn']/@value"/></familyName>
+                            <givenName><xsl:value-of select="//attribute[@name='givenName']/@value"/></givenName>
+                            <middleNames/>
+                            <suffix/>
+                        </user>
+                    </xsl:when>
                     <!-- California Lutheran University [SAML SSO] (CALLUTHERAN)-->
                     <xsl:when test="$idp='login.callutheran.edu'">
                         <id>callutheran</id>
@@ -65,6 +77,18 @@
                             <fullname><xsl:value-of select="//attribute[@name='displayName']/@value"/></fullname>
                             <familyName/>
                             <givenName/>
+                            <middleNames/>
+                            <suffix/>
+                        </user>
+                    </xsl:when>
+                    <!-- Princeton University (PU) -->
+                    <xsl:when test="$idp='https://idp.princeton.edu/idp/shibboleth'">
+                        <id>pu</id>
+                        <user>
+                            <username><xsl:value-of select="//attribute[@name='mail']/@value"/></username>
+                            <fullname><xsl:value-of select="//attribute[@name='displayName']/@value"/></fullname>
+                            <familyName><xsl:value-of select="//attribute[@name='sn']/@value"/></familyName>
+                            <givenName><xsl:value-of select="//attribute[@name='givenName']/@value"/></givenName>
                             <middleNames/>
                             <suffix/>
                         </user>

--- a/etc/institutions-auth.xsl
+++ b/etc/institutions-auth.xsl
@@ -65,6 +65,7 @@
                             <fullname><xsl:value-of select="//attribute[@name='displayName']/@value"/></fullname>
                             <familyName><xsl:value-of select="//attribute[@name='sn']/@value"/></familyName>
                             <givenName><xsl:value-of select="//attribute[@name='givenName']/@value"/></givenName>
+                            <isMemberOf><xsl:value-of select="//attribute[@name='isMemberOf']/@value"/></isMemberOf>
                             <middleNames/>
                             <suffix/>
                         </user>


### PR DESCRIPTION
## Ticket

https://openscience.atlassian.net/browse/ENG-1429

## Purpose

This is the accompanying PR for https://github.com/CenterForOpenScience/osf.io/pull/9484 of which the purpose is:

* Implement a feature that different institutions can share the same SSO
* Add the `thepolicylab` to prod using brown's SSO of type `saml-shib`

## Changes

* Updated institution authentication XSLT, which affects local dev / test only
  * Added `princeton` as it is in the server settings, which is a leftover from previous tasks
  * Added and updated `brown` to include the `isMemberOf` attribute
* Added `isMemberOf` to a couple of logging messages

## Dev / QA Notes

I finally figured out a way to test institution SSO  without an existing accounts / IdP servers. Verified all three cases below work as expected. The local OSF API server creates new (finds existing) users and affiliates institutions (if not) correctly.

* `brown`-only user

```
2020-09-17 00:51:17,408 INFO [io.cos.cas.authentication.handler.support.OpenScienceFrameworkPrincipalFromRequestRemoteUserNonInteractiveCredentialsAction] - <[SAML Shibboleth] User's institutional identity: 'roger4321'>
2020-09-17 00:51:17,408 DEBUG [io.cos.cas.authentication.handler.support.OpenScienceFrameworkPrincipalFromRequestRemoteUserNonInteractiveCredentialsAction] - <[SAML Shibboleth] User's institutional identity 'roger4321' - auth header 'AUTH-sn': 'Deng'>
2020-09-17 00:51:17,408 DEBUG [io.cos.cas.authentication.handler.support.OpenScienceFrameworkPrincipalFromRequestRemoteUserNonInteractiveCredentialsAction] - <[SAML Shibboleth] User's institutional identity 'roger4321' - auth header 'AUTH-fullname': 'Roger Deng'>
2020-09-17 00:51:17,408 DEBUG [io.cos.cas.authentication.handler.support.OpenScienceFrameworkPrincipalFromRequestRemoteUserNonInteractiveCredentialsAction] - <[SAML Shibboleth] User's institutional identity 'roger4321' - auth header 'AUTH-isMemberOf': 'thepolicylab'>
2020-09-17 00:51:17,408 DEBUG [io.cos.cas.authentication.handler.support.OpenScienceFrameworkPrincipalFromRequestRemoteUserNonInteractiveCredentialsAction] - <[SAML Shibboleth] User's institutional identity 'roger4321' - auth header 'AUTH-mail': 'roger@brown.edu'>
2020-09-17 00:51:17,408 DEBUG [io.cos.cas.authentication.handler.support.OpenScienceFrameworkPrincipalFromRequestRemoteUserNonInteractiveCredentialsAction] - <[SAML Shibboleth] User's institutional identity 'roger4321' - auth header 'AUTH-givenName': 'Roger'>
2020-09-17 00:51:17,408 DEBUG [io.cos.cas.authentication.handler.support.OpenScienceFrameworkPrincipalFromRequestRemoteUserNonInteractiveCredentialsAction] - <[SAML Shibboleth] User's institutional identity 'roger4321' - auth header 'AUTH-Shib-Identity-Provider': 'https://sso.brown.edu/idp/shibboleth'>
2020-09-17 00:51:17,412 INFO [io.cos.cas.authentication.handler.support.OpenScienceFrameworkPrincipalFromRequestRemoteUserNonInteractiveCredentialsAction] - <[CAS XSLT] Secondary institution detected. SSO is 'brown' and member is 'thepolicylab'>
2020-09-17 00:51:17,412 INFO [io.cos.cas.authentication.handler.support.OpenScienceFrameworkPrincipalFromRequestRemoteUserNonInteractiveCredentialsAction] - <[CAS XSLT] All attributes checked: username=roger@brown.edu, institution=brown, member=thepolicylab>
2020-09-17 00:51:17,413 DEBUG [io.cos.cas.authentication.handler.support.OpenScienceFrameworkPrincipalFromRequestRemoteUserNonInteractiveCredentialsAction] - <[CAS XSLT] All attributes checked: username=roger@brown.edu, institution=brown, member=thepolicylab, normalizedPayload={"provider":{"idp":"https://sso.brown.edu/idp/shibboleth","id":"brown","user":{"middleNames":"","familyName":"Deng","givenName":"Roger","isMemberOf":"thepolicylab","fullname":"","suffix":"","username":"roger@brown.edu"}}}>
2020-09-17 00:51:34,748 WARN [org.apache.http.client.protocol.ResponseProcessCookies] - <Cookie rejected [sloan_id="1028cc7d-d933-4c43-bcfe-69a31383ff2c", version:0, domain:osf.io, path:/, expiry:null] Illegal 'domain' attribute "osf.io". Domain of origin: "localhost">
2020-09-17 00:51:34,748 INFO [io.cos.cas.authentication.handler.support.OpenScienceFrameworkPrincipalFromRequestRemoteUserNonInteractiveCredentialsAction] - <[OSF API] Notify Remote Principal Authenticated Response: username=roger@brown.edu statusCode=204>
```

* `brown` and `thepolicylab` user

```
2020-09-17 00:54:32,059 INFO [io.cos.cas.authentication.handler.support.OpenScienceFrameworkPrincipalFromRequestRemoteUserNonInteractiveCredentialsAction] - <[SAML Shibboleth] User's institutional identity: 'longze1234'>
2020-09-17 00:54:32,059 DEBUG [io.cos.cas.authentication.handler.support.OpenScienceFrameworkPrincipalFromRequestRemoteUserNonInteractiveCredentialsAction] - <[SAML Shibboleth] User's institutional identity 'longze1234' - auth header 'AUTH-sn': 'Chen'>
2020-09-17 00:54:32,059 DEBUG [io.cos.cas.authentication.handler.support.OpenScienceFrameworkPrincipalFromRequestRemoteUserNonInteractiveCredentialsAction] - <[SAML Shibboleth] User's institutional identity 'longze1234' - auth header 'AUTH-fullname': 'Longze Chen'>
2020-09-17 00:54:32,059 DEBUG [io.cos.cas.authentication.handler.support.OpenScienceFrameworkPrincipalFromRequestRemoteUserNonInteractiveCredentialsAction] - <[SAML Shibboleth] User's institutional identity 'longze1234' - auth header 'AUTH-mail': 'longze@brown.edu'>
2020-09-17 00:54:32,059 DEBUG [io.cos.cas.authentication.handler.support.OpenScienceFrameworkPrincipalFromRequestRemoteUserNonInteractiveCredentialsAction] - <[SAML Shibboleth] User's institutional identity 'longze1234' - auth header 'AUTH-givenName': 'Longze'>
2020-09-17 00:54:32,059 DEBUG [io.cos.cas.authentication.handler.support.OpenScienceFrameworkPrincipalFromRequestRemoteUserNonInteractiveCredentialsAction] - <[SAML Shibboleth] User's institutional identity 'longze1234' - auth header 'AUTH-Shib-Identity-Provider': 'https://sso.brown.edu/idp/shibboleth'>
2020-09-17 00:54:32,062 INFO [io.cos.cas.authentication.handler.support.OpenScienceFrameworkPrincipalFromRequestRemoteUserNonInteractiveCredentialsAction] - <[CAS XSLT] All attributes checked: username=longze@brown.edu, institution=brown, member=>
2020-09-17 00:54:32,062 DEBUG [io.cos.cas.authentication.handler.support.OpenScienceFrameworkPrincipalFromRequestRemoteUserNonInteractiveCredentialsAction] - <[CAS XSLT] All attributes checked: username=longze@brown.edu, institution=brown, member=, normalizedPayload={"provider":{"idp":"https://sso.brown.edu/idp/shibboleth","id":"brown","user":{"middleNames":"","familyName":"Chen","givenName":"Longze","isMemberOf":"","fullname":"","suffix":"","username":"longze@brown.edu"}}}>
2020-09-17 00:54:32,992 WARN [org.apache.http.client.protocol.ResponseProcessCookies] - <Cookie rejected [sloan_id="ba2cc1c5-6b9a-42ac-bd62-078d1ddd8836", version:0, domain:osf.io, path:/, expiry:null] Illegal 'domain' attribute "osf.io". Domain of origin: "localhost">
2020-09-17 00:54:32,992 INFO [io.cos.cas.authentication.handler.support.OpenScienceFrameworkPrincipalFromRequestRemoteUserNonInteractiveCredentialsAction] - <[OSF API] Notify Remote Principal Authenticated Response: username=longze@brown.edu statusCode=204>
```

* `princeton` user

This is to test that other institutions are not affected by the fact that `isMemberOf` is only added to `brown`.

```
2020-09-17 01:00:41,625 INFO [io.cos.cas.authentication.handler.support.OpenScienceFrameworkPrincipalFromRequestRemoteUserNonInteractiveCredentialsAction] - <[SAML Shibboleth] User's institutional identity: 'albert1342'>
2020-09-17 01:00:41,625 DEBUG [io.cos.cas.authentication.handler.support.OpenScienceFrameworkPrincipalFromRequestRemoteUserNonInteractiveCredentialsAction] - <[SAML Shibboleth] User's institutional identity 'albert1342' - auth header 'AUTH-displayName': 'Albert The Dog'>
2020-09-17 01:00:41,626 DEBUG [io.cos.cas.authentication.handler.support.OpenScienceFrameworkPrincipalFromRequestRemoteUserNonInteractiveCredentialsAction] - <[SAML Shibboleth] User's institutional identity 'albert1342' - auth header 'AUTH-sn': 'null'>
2020-09-17 01:00:41,626 DEBUG [io.cos.cas.authentication.handler.support.OpenScienceFrameworkPrincipalFromRequestRemoteUserNonInteractiveCredentialsAction] - <[SAML Shibboleth] User's institutional identity 'albert1342' - auth header 'AUTH-mail': 'albert@princeton.edu'>
2020-09-17 01:00:41,626 DEBUG [io.cos.cas.authentication.handler.support.OpenScienceFrameworkPrincipalFromRequestRemoteUserNonInteractiveCredentialsAction] - <[SAML Shibboleth] User's institutional identity 'albert1342' - auth header 'AUTH-givenName': 'Albert'>
2020-09-17 01:00:41,626 DEBUG [io.cos.cas.authentication.handler.support.OpenScienceFrameworkPrincipalFromRequestRemoteUserNonInteractiveCredentialsAction] - <[SAML Shibboleth] User's institutional identity 'albert1342' - auth header 'AUTH-Shib-Identity-Provider': 'https://idp.princeton.edu/idp/shibboleth'>
2020-09-17 01:00:41,628 INFO [io.cos.cas.authentication.handler.support.OpenScienceFrameworkPrincipalFromRequestRemoteUserNonInteractiveCredentialsAction] - <[CAS XSLT] All attributes checked: username=albert@princeton.edu, institution=pu, member=>
2020-09-17 01:00:41,628 DEBUG [io.cos.cas.authentication.handler.support.OpenScienceFrameworkPrincipalFromRequestRemoteUserNonInteractiveCredentialsAction] - <[CAS XSLT] All attributes checked: username=albert@princeton.edu, institution=pu, member=, normalizedPayload={"provider":{"idp":"https://idp.princeton.edu/idp/shibboleth","id":"pu","user":{"middleNames":"","familyName":"","givenName":"Albert","fullname":"Albert The Dog","suffix":"","username":"albert@princeton.edu"}}}>
2020-09-17 01:01:09,550 WARN [org.apache.http.client.protocol.ResponseProcessCookies] - <Cookie rejected [sloan_id="f1ebd793-7ff2-4513-927d-b93d7056689d", version:0, domain:osf.io, path:/, expiry:null] Illegal 'domain' attribute "osf.io". Domain of origin: "localhost">
2020-09-17 01:01:09,550 INFO [io.cos.cas.authentication.handler.support.OpenScienceFrameworkPrincipalFromRequestRemoteUserNonInteractiveCredentialsAction] - <[OSF API] Notify Remote Principal Authenticated Response: username=albert@princeton.edu statusCode=204>
```

## Dev-Ops Notes

See https://github.com/CenterForOpenScience/osf.io/pull/9484 for configurations for Shibboleth, CAS and OSF.
