### PR TITLE
[ENG-1429] [OSF Institutions] Fix Key Uniqueness of Institution Login URL Map

### DIFF
--- a/cas-server-support-osf/src/main/java/io/cos/cas/adaptors/postgres/handlers/OpenScienceFrameworkInstitutionHandler.java
+++ b/cas-server-support-osf/src/main/java/io/cos/cas/adaptors/postgres/handlers/OpenScienceFrameworkInstitutionHandler.java
@@ -72,13 +72,16 @@ public class OpenScienceFrameworkInstitutionHandler {
     }
 
     /**
-     * <p>Return a map of institution login url or institution ID as key and institution name as value.</p>
+     * <p>Return a map, in which the institution ID or login URL is the key and the institution name is the value.</p>
      *
-     * <p>For saml-shib institutions, the login url is the key and the institution display name is the value.</p>
+     * <p>For saml-shib institutions, the login URL is the key and the institution's display name is the value. A
+     * fragment hash followed by the institution ID is appended to each login URL to ensure key uniqueness in the
+     * presence of shared SSO between institutions. The fragment part does not affect the functionality of the login
+     * URL but it will be removed anyway by a script on the front-end page before being set to the window location.</p>
      *
-     * <p>For cas-pac4j institutions, the institution ID is the key and the institution display name is the value. </p>
+     * <p>For cas-pac4j institutions, the institution ID is the key and the institution's display name is the value.</p>
      *
-     * @param target the osf service target after successful institution login, only used for "saml-shib" institutions
+     * @param target the OSF service target after successful institution login, only used for "saml-shib" institutions
      * @param id the OSF institution ID if auto-selection is enabled
      * @return a single-entry {@link Map} if <code>id</code> presents and if the institution this <code>id</code>
      *         identifies exists and supports institution SSO; otherwise return a multi-entry {@link Map} of all.
@@ -102,7 +105,12 @@ public class OpenScienceFrameworkInstitutionHandler {
         for (final OpenScienceFrameworkInstitution institution: institutionList) {
             final DelegationProtocol delegationProtocol = institution.getDelegationProtocol();
             if (DelegationProtocol.SAML_SHIB.equals(delegationProtocol)) {
-                institutionLoginUrlMap.put(institution.getLoginUrl() + "&target=" + target, institution.getName());
+                // With shared SSO between institutions such as Brown University and The Policy Lab, the login URL is
+                // the same for both. Must add "#" with institution ID to enforce key uniqueness.
+                institutionLoginUrlMap.put(
+                        institution.getLoginUrl() + "&target=" + target + '#' + institution.getId(),
+                        institution.getName()
+                );
             } else if (DelegationProtocol.CAS_PAC4J.equals(delegationProtocol)) {
                 institutionLoginUrlMap.put(institution.getId(), institution.getName());
             }

--- a/cas-server-webapp/src/main/webapp/WEB-INF/view/jsp/default/ui/casInstitutionLoginView.jsp
+++ b/cas-server-webapp/src/main/webapp/WEB-INF/view/jsp/default/ui/casInstitutionLoginView.jsp
@@ -99,9 +99,9 @@
 
         function institutionLogin () {
 
-            var institutionForm = document.getElementById("institution-form-select");
-            var institutionLoginUrl = institutionForm.options[institutionForm.selectedIndex].value;
-            var selectErrorMessage = document.getElementById("select-error-message");
+            let institutionForm = document.getElementById("institution-form-select");
+            let institutionLoginUrl = institutionForm.options[institutionForm.selectedIndex].value;
+            let selectErrorMessage = document.getElementById("select-error-message");
 
             if(institutionLoginUrl == null || institutionLoginUrl === "") {
                 selectErrorMessage.style.display = "inline";
@@ -112,10 +112,17 @@
                 institutionLoginUrl = "${okstateUrl}";
             } else if (institutionLoginUrl === "cord") {
                 institutionLoginUrl = "${cordUrl}"
+            } else {
+                // Removing the fragment part of the login URL is not necessary but a good-to-have. Thus, neither will
+                // we run into nor do we need to worry about weird corner cases if somehow it breaks login endpoints.
+                let lastIndexOfHash = institutionLoginUrl.lastIndexOf("#");
+                if (lastIndexOfHash >= 0) {
+                    institutionLoginUrl = institutionLoginUrl.substring(0, lastIndexOfHash);
+                }
             }
 
-            var consentCheckbox = document.getElementById('consent-checkbox');
-            var consentErrorMessage = document.getElementById("consent-error-message");
+            let consentCheckbox = document.getElementById('consent-checkbox');
+            let consentErrorMessage = document.getElementById("consent-error-message");
             if (consentCheckbox != null && !consentCheckbox.checked) {
                 consentErrorMessage.style.display = "inline";
             } else {
@@ -125,7 +132,7 @@
 
         function checkConsent(checkbox) {
 
-            var consentErrorMessage = document.getElementById("consent-error-message");
+            let consentErrorMessage = document.getElementById("consent-error-message");
             if (consentErrorMessage != null) {
                 consentErrorMessage.style.display = checkbox.checked ? "none" : "inline";
             }
@@ -133,12 +140,12 @@
 
         function checkSelect() {
 
-            var selectErrorMessage = document.getElementById("select-error-message");
+            let selectErrorMessage = document.getElementById("select-error-message");
             if (selectErrorMessage != null) {
                 selectErrorMessage.style.display = "none";
             }
 
-            var consentErrorMessage = document.getElementById("consent-error-message");
+            let consentErrorMessage = document.getElementById("consent-error-message");
             if (consentErrorMessage != null) {
                 consentErrorMessage.style.display = "none";
             }


### PR DESCRIPTION
## Ticket

https://openscience.atlassian.net/browse/ENG-1429

## Purpose 

With the introduction of shared-SSO between institutions (https://github.com/CenterForOpenScience/cas-overlay/pull/189 and https://github.com/CenterForOpenScience/osf.io/pull/9484), the login URL (being the key of a map) is no longer unique. This leads to a bug where only one institution of those who share the same SSO will be displayed in the drop-down list. This PR fix this problem.

## Changes

A fragment is added to each login URL with the institution ID in order to preserve the uniqueness. For example, both Brown University and The Policy Lab at Brown University use the same login endpoint but now have different URLs after this change.

* Brown Univ. - `https://<brown.login.url>#brown`
* The Policy Lab - `https://<brown.login.url>#thepolicylab`

Thus, the map can be constructed without missing institutions and sent to the front-end to automatically populate the `<option>` list of the drop-down `<select>` tag. The fragment is removed by the front-end script later on the page after the sign-in button is clicked and before the new `window.location` is set.

![shared-sso-brown-and-the-policy-lab](https://user-images.githubusercontent.com/3750414/93556226-3fb3db00-f946-11ea-9d2a-bbb1439a9442.png)

In addition, I have verified that this works with auto-select institution introduced in https://github.com/CenterForOpenScience/cas-overlay/pull/184.

![auto-select-institution](https://user-images.githubusercontent.com/3750414/93556563-03cd4580-f947-11ea-93af-9ef84a571db6.png)

Finally, refactored the scripts in the institution login page to use `let` instead of `var`, which is safe since the browsers we support all support it (see [here](https://stackoverflow.com/questions/2356830/what-browsers-currently-support-javascripts-let-keyword)).

## Dev / QA Notes

N / A

## Dev-Ops Notes

N / A
