### PR TITLE
[ENG-1592] [ENG-2270] [ENG-2294] Department Attribute Update

### DIFF
--- a/cas-server-support-osf/src/main/java/io/cos/cas/authentication/handler/support/OpenScienceFrameworkPrincipalFromRequestRemoteUserNonInteractiveCredentialsAction.java
+++ b/cas-server-support-osf/src/main/java/io/cos/cas/authentication/handler/support/OpenScienceFrameworkPrincipalFromRequestRemoteUserNonInteractiveCredentialsAction.java
@@ -75,6 +75,8 @@ import org.springframework.webflow.execution.RequestContext;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
+import javax.naming.InvalidNameException;
+import javax.naming.ldap.LdapName;
 import javax.security.auth.login.AccountException;
 import javax.security.auth.login.FailedLoginException;
 import javax.servlet.http.Cookie;
@@ -169,6 +171,8 @@ public class OpenScienceFrameworkPrincipalFromRequestRemoteUserNonInteractiveCre
     private static final String SHIBBOLETH_SESSION_HEADER = ATTRIBUTE_PREFIX + "Shib-Session-ID";
 
     private static final String SHIBBOLETH_COOKIE_PREFIX = "_shibsession_";
+
+    private static final String LDAP_DN_OU_PREFIX = "ou=";
 
     private static final int SIXTY_SECONDS = 60 * 1000;
 
@@ -581,6 +585,22 @@ public class OpenScienceFrameworkPrincipalFromRequestRemoteUserNonInteractiveCre
                     isMemberOf
             );
         }
+
+        final String departmentRaw = user.optString("departmentRaw").trim();
+        // Unlike all the above attributes that are released to us from the institutions, the `eduPerson` is a boolean
+        // per-institution flag set by CAS in the "institutions-auth.xsl" file. It determines whether the department
+        // attribute uses the the eduPerson schema (https://wiki.refeds.org/display/STAN/eduPerson).
+        final boolean eduPerson = user.optBoolean("eduPerson");
+
+        String department = "";
+        if (departmentRaw.isEmpty()) {
+            logger.warn("[CAS XSLT] Missing department: fullname={}, username={}, institution={}", fullname, username, institutionId);
+        } else {
+            department = this.retrieveDepartment(departmentRaw, eduPerson);
+        }
+        // Insert the `department` attribute into the payload, which does not overwrite `departmentRaw`.
+        normalizedPayload.getJSONObject("provider").getJSONObject("user").put("department", department);
+
         final String payload = normalizedPayload.toString();
         logger.info(
                 "[CAS XSLT] All attributes checked: username={}, institution={}, member={}",
@@ -697,6 +717,42 @@ public class OpenScienceFrameworkPrincipalFromRequestRemoteUserNonInteractiveCre
 
         // convert transformed xml to json
         return XML.toJSONObject(writer.getBuffer().toString());
+    }
+
+    /**
+     * Retrieve the department value from the raw department string.
+     *
+     * @param departmentRaw the raw department string
+     * @param eduPerson whether the department attribute uses eduPerson schema
+     * @return the department value
+     */
+    private String retrieveDepartment(final String departmentRaw, final boolean eduPerson) {
+
+        // Return the raw value as it is if institutions do not use eduPerson schema for the department attribute
+        if (!eduPerson) {
+            return departmentRaw;
+        }
+
+        // For institutions that use the eduPerson schema, the department must be retrieved from the raw value. Here is
+        // an example: "ou=Music Department, o=Notre Dame, dc=nd, dc=edu", whose syntax is LDAP Distinguished Names.
+        try {
+            final LdapName dn = new LdapName(departmentRaw);
+            for (int i = dn.size() - 1; i >=0; i--) {
+                final String rdn = dn.get(i);
+                if (rdn.startsWith(LDAP_DN_OU_PREFIX)) {
+                    return rdn.substring(LDAP_DN_OU_PREFIX.length());
+                }
+            }
+        } catch (final InvalidNameException | IndexOutOfBoundsException e) {
+            logger.error(
+                    "[CAS XSLT] Invalid syntax for LDAP Distinguished Names: departmentRaw={}, error={}",
+                    departmentRaw,
+                    e.getMessage()
+            );
+            // Return an empty string if the syntax is wrong
+            return "";
+        }
+        return "";
     }
 
     public void setInstitutionsAuthUrl(final String institutionsAuthUrl) {

--- a/etc/institutions-auth.xsl
+++ b/etc/institutions-auth.xsl
@@ -85,6 +85,10 @@
                         </user>
                     </xsl:when>
                     <!-- Princeton University (PU) -->
+                    <!--
+                        The departmentRaw and eduPerson attributes are for local testing purpose only.
+                        Princeton does not release such an attribute yet.
+                    -->
                     <xsl:when test="$idp='https://idp.princeton.edu/idp/shibboleth'">
                         <id>pu</id>
                         <user>
@@ -92,6 +96,25 @@
                             <fullname><xsl:value-of select="//attribute[@name='displayName']/@value"/></fullname>
                             <familyName><xsl:value-of select="//attribute[@name='sn']/@value"/></familyName>
                             <givenName><xsl:value-of select="//attribute[@name='givenName']/@value"/></givenName>
+                            <departmentRaw><xsl:value-of select="//attribute[@name='department']/@value"/></departmentRaw>
+                            <eduPerson>true</eduPerson>
+                            <suffix/>
+                        </user>
+                    </xsl:when>
+                    <!-- University of Arizona (UA) -->
+                    <!--
+                        The departmentRaw and eduPerson attributes are both for production and local testing purposes.
+                        University of Arizona is the first institution to release the department attribute to OSF.
+                    -->
+                    <xsl:when test="$idp='urn:mace:incommon:arizona.edu'">
+                        <id>ua</id>
+                        <user>
+                            <username><xsl:value-of select="//attribute[@name='mail']/@value"/></username>
+                            <fullname><xsl:value-of select="//attribute[@name='displayName']/@value"/></fullname>
+                            <familyName><xsl:value-of select="//attribute[@name='sn']/@value"/></familyName>
+                            <givenName><xsl:value-of select="//attribute[@name='givenName']/@value"/></givenName>
+                            <departmentRaw><xsl:value-of select="//attribute[@name='department']/@value"/></departmentRaw>
+                            <eduPerson>false</eduPerson>
                             <middleNames/>
                             <suffix/>
                         </user>

--- a/etc/institutions-auth.xsl
+++ b/etc/institutions-auth.xsl
@@ -36,10 +36,12 @@
                         <id>esu</id>
                         <user>
                             <!--  Each institution has its customized mapping of attributes  -->
-                            <username><xsl:value-of select="//attribute[@name='eppn']/@value"/></username>
+                            <username><xsl:value-of select="//attribute[@name='mail']/@value"/></username>
                             <fullname><xsl:value-of select="//attribute[@name='displayedName']/@value"/></fullname>
                             <familyName><xsl:value-of select="//attribute[@name='sn']/@value"/></familyName>
                             <givenName><xsl:value-of select="//attribute[@name='givenName']/@value"/></givenName>
+                            <departmentRaw><xsl:value-of select="//attribute[@name='department']/@value"/></departmentRaw>
+                            <eduPerson>true</eduPerson>
                             <middleNames/>
                             <suffix/>
                         </user>
@@ -150,6 +152,8 @@
                             <fullname><xsl:value-of select="//attribute[@name='displayName']/@value"/></fullname>
                             <familyName><xsl:value-of select="//attribute[@name='sn']/@value"/></familyName>
                             <givenName><xsl:value-of select="//attribute[@name='givenName']/@value"/></givenName>
+                            <departmentRaw><xsl:value-of select="//attribute[@name='department']/@value"/></departmentRaw>
+                            <eduPerson>false</eduPerson>
                             <middleNames/>
                             <suffix/>
                         </user>

--- a/postman/osf-cas-shib-saml-instn-sso-test.json
+++ b/postman/osf-cas-shib-saml-instn-sso-test.json
@@ -1,0 +1,269 @@
+{
+	"info": {
+		"_postman_id": "390768cf-591d-455f-a623-d0734d07adfe",
+		"name": "OSF Institution Shib-SAML SSO",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+	},
+	"item": [
+		{
+			"name": "Brown University User",
+			"request": {
+				"method": "GET",
+				"header": [
+					{
+						"key": "AUTH-mail",
+						"value": "chen@brown.edu",
+						"type": "text"
+					},
+					{
+						"key": "AUTH-displayName",
+						"value": "Longzebrown Chenbrown",
+						"type": "text"
+					},
+					{
+						"key": "AUTH-givenName",
+						"value": "Longzebrown",
+						"type": "text"
+					},
+					{
+						"key": "AUTH-sn",
+						"value": "Chenbrown",
+						"type": "text"
+					},
+					{
+						"key": "REMOTE_USER",
+						"value": "chenbrown123",
+						"type": "text"
+					},
+					{
+						"key": "AUTH-Shib-Session-ID",
+						"value": "1234567812345678",
+						"type": "text"
+					},
+					{
+						"key": "AUTH-Shib-Identity-Provider",
+						"value": "https://sso.brown.edu/idp/shibboleth",
+						"type": "text"
+					}
+				],
+				"url": {
+					"raw": "http://localhost:8080/login",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "8080",
+					"path": [
+						"login"
+					]
+				},
+				"description": "Standard SAML SSO without shared SSO and without the department attribute."
+			},
+			"response": []
+		},
+		{
+			"name": "The Policy Lab User",
+			"request": {
+				"method": "GET",
+				"header": [
+					{
+						"key": "AUTH-mail",
+						"value": "chen@policylab.io",
+						"type": "text"
+					},
+					{
+						"key": "AUTH-displayName",
+						"value": "Longzepolicylab Chenpolicylab",
+						"type": "text"
+					},
+					{
+						"key": "AUTH-givenName",
+						"value": "Longzepolicylab",
+						"type": "text"
+					},
+					{
+						"key": "AUTH-sn",
+						"value": "Chenpolicylab",
+						"type": "text"
+					},
+					{
+						"key": "REMOTE_USER",
+						"value": "chenpolicylab123",
+						"type": "text"
+					},
+					{
+						"key": "AUTH-Shib-Session-ID",
+						"value": "1234567812345678",
+						"type": "text"
+					},
+					{
+						"key": "AUTH-Shib-Identity-Provider",
+						"value": "https://sso.brown.edu/idp/shibboleth",
+						"type": "text"
+					},
+					{
+						"key": "AUTH-isMemberOf",
+						"value": "thepolicylab",
+						"type": "text"
+					}
+				],
+				"url": {
+					"raw": "http://localhost:8080/login",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "8080",
+					"path": [
+						"login"
+					]
+				},
+				"description": "A SAML SSO institution user using another (the primary) institution's SSO server with an extra attribute indicate which secondary institution the user belongs to."
+			},
+			"response": []
+		},
+		{
+			"name": "University of Arizona User",
+			"request": {
+				"method": "GET",
+				"header": [
+					{
+						"key": "AUTH-mail",
+						"type": "text",
+						"value": "chen@ua.edu"
+					},
+					{
+						"key": "AUTH-displayName",
+						"type": "text",
+						"value": "Longzeua Chenua"
+					},
+					{
+						"key": "AUTH-givenName",
+						"type": "text",
+						"value": "Longzeua"
+					},
+					{
+						"key": "AUTH-sn",
+						"type": "text",
+						"value": "Chenua"
+					},
+					{
+						"key": "REMOTE_USER",
+						"type": "text",
+						"value": "chenua12"
+					},
+					{
+						"key": "AUTH-Shib-Session-ID",
+						"type": "text",
+						"value": "1234567812345678"
+					},
+					{
+						"key": "AUTH-Shib-Identity-Provider",
+						"type": "text",
+						"value": "urn:mace:incommon:arizona.edu"
+					},
+					{
+						"key": "AUTH-department",
+						"value": "Department of Computer Science",
+						"type": "text"
+					}
+				],
+				"url": {
+					"raw": "http://localhost:8080/login",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "8080",
+					"path": [
+						"login"
+					]
+				},
+				"description": "A SAML SSO institution user with the department information released using a customized attribute. OSF CAS will take it as it is."
+			},
+			"response": []
+		},
+		{
+			"name": "Clear CAS Session",
+			"request": {
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "http://localhost:8080/logout",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "8080",
+					"path": [
+						"logout"
+					]
+				},
+				"description": "Clear successful SSO sessions created by each test."
+			},
+			"response": []
+		},
+		{
+			"name": "Princeton User",
+			"request": {
+				"method": "GET",
+				"header": [
+					{
+						"key": "AUTH-mail",
+						"value": "chen@princeton.edu",
+						"type": "text"
+					},
+					{
+						"key": "AUTH-displayName",
+						"value": "Longzepu Chen pu",
+						"type": "text"
+					},
+					{
+						"key": "AUTH-givenName",
+						"value": "Longzepu",
+						"type": "text"
+					},
+					{
+						"key": "AUTH-sn",
+						"value": "Chenpu",
+						"type": "text"
+					},
+					{
+						"key": "REMOTE_USER",
+						"value": "chenpu12",
+						"type": "text"
+					},
+					{
+						"key": "AUTH-Shib-Identity-Provider",
+						"value": "https://idp.princeton.edu/idp/shibboleth",
+						"type": "text"
+					},
+					{
+						"key": "AUTH-department",
+						"value": "ou=Music Department, o=Princton Uiniversity, dc=princeton, dc=edu",
+						"type": "text"
+					},
+					{
+						"key": "AUTH-Shib-Session-Id",
+						"value": "1234567812345678",
+						"type": "text"
+					}
+				],
+				"url": {
+					"raw": "http://localhost:8080/login",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "8080",
+					"path": [
+						"login"
+					]
+				},
+				"description": "A SAML SSO institution user with the department attribute released using eduPerson of which the syntax is LDAP Distinguished Names."
+			},
+			"response": []
+		}
+	],
+	"protocolProfileBehavior": {}
+}


### PR DESCRIPTION
## Ticket

Initial implementation: [ENG-1592](https://openscience.atlassian.net/browse/ENG-1592)
Department update: [ENG-2270](https://openscience.atlassian.net/browse/ENG-2270)
University of Arizona: [ENG-2294](https://openscience.atlassian.net/browse/ENG-2294)

## Purpose

Support the `department` attribute in released institutional attributes.

## Changes

### Support Department

The name and value of the department attribute, unlike others, is schema specific per institution.

Currently CAS supports only one - the `eduPerson` schema, which is a LDAP schema where the attribute for department `eduPersonPrimaryOrgUnitDN` is of the syntax "LDAP Distinguished Names". In this case, CAS uses one RDN `ou=<department_name>` to retrieve the department information.

For all other cases, CAS uses the raw value.

If the department is not provided, is empty or is of invalid format, CAS set its value to an empty string.

### Postman Tests

Created postman tests that mock the Shibboleth server to test four types of SAML SSO for institution.

* Standard SAML SSO without shared SSO and without the department attribute
* A SAML SSO institution user using another (the primary) institution's SSO server with an extra attribute indicate which secondary institution the user belongs to.
* A SAML SSO institution user with the department information released using a customized attribute. OSF CAS will take it as it is.
* A SAML SSO institution user with the department attribute released using eduPerson of which the syntax is LDAP Distinguished Names.

## Dev / QA Notes

- [x] OSF side needs this [PR / commit](https://github.com/CenterForOpenScience/osf.io/commit/9b883a570ad588aecec4bf064c21bf15c6f8088f) with migrations.

- Simply use the postman tests to test different types of SAML institution SSO

## Dev-Ops Note

**Test server only for now**
**Prod settings can be updated w/o affecting existing SSO. Don't deploy prod until verified by the institution.**

* No OSF side change or database update since University of Arizona is an existing institution

* Jetty CAS: add the following two attributes to University of Arizona in `institutions-auth.sxl`. You can search for `<xsl:when test="$idp='urn:mace:incommon:arizona.edu'">`
```
<departmentRaw><xsl:value-of select="//attribute[@name='department']/@value"/></departmentRaw>
<eduPerson>false</eduPerson>
```

* Apache Shibboleth: add the following attribute to the `attribute-map.xml`
```
<!-- University of Arizona (UA) -->
<!--
    The attribute that UA released has a friendly name "employeePrimaryDeptName". However, OSF Shibboleth maps the
    OID directly to "department" for institutions-auth.xsl (OSF CAS) to use for XML tranformation. Thus, there is
    no need to track what friendly name each institution use for department in that XSL file.
-->
<Attribute name="urn:oid:1.3.6.1.4.1.5643.10.0.52" id="department"/>
```
