### PR TITLE
[Replaced by #195] [ENG-2241] Guide Users from Unsupported Institutions

### DIFF
--- a/cas-server-webapp/src/main/resources/messages.properties
+++ b/cas-server-webapp/src/main/resources/messages.properties
@@ -181,11 +181,23 @@ screen.institution.login.heading=Sign in through institution
 screen.institution.login.select=Select your institution
 screen.institution.login.select.auto=Your institution
 screen.institution.login.select.all=Not your institution?
+screen.institution.login.select.unsupported=I can't find my institution
 screen.institution.login.message=If your institution has partnered with OSF, please select its name below and sign in with your institutional credentials.<br/><br/>If you do not currently have an OSF account, this will create one for you.
 screen.institution.login.osf=Log in with OSF
 screen.institution.login.consent.checkbox=I have read and agree to the <a style="white-space: nowrap" href=https://github.com/CenterForOpenScience/centerforopenscience.org/blob/master/TERMS_OF_USE.md>Terms of Use</a> and <a style="white-space: nowrap" href=https://github.com/CenterForOpenScience/centerforopenscience.org/blob/master/PRIVACY_POLICY.md>Privacy Policy</a>.
 screen.institution.login.consent.error.message=You must read and agree to the <span style="white-space: nowrap">Terms of Use</span> and <span style="white-space: nowrap">Privacy Policy</span>.
 screen.institution.login.select.error.message=You must select an institution.
+screen.institution.login.unknown=I can't find my institution
+
+# Unsupported Institution
+screen.unsupportedinstitution.login.message=Signing into the OSF with institutional credentials is enabled for <a href="{0}">OSF Institutions members</a>.  If your institution is not yet an OSFI member, choose one of the following sign-in methods.
+screen.unsupportedinstitution.login.existing.heading=I already have an OSF account
+screen.unsupportedinstitution.login.existing.osf.message=If you have already have an OSF password, you can sign in to the OSF
+screen.unsupportedinstitution.login.existing.osf.button=Log in with OSF
+screen.unsupportedinstitution.login.existing.institution.message=If you have not yet set an OSF password for your account, create a password
+screen.unsupportedinstitution.login.existing.institution.button=Set a password
+screen.unsupportedinstitution.login.new.heading=I want to register for an OSF account
+screen.unsupportedinstitution.login.new.message=<a href="{0}">Register for an OSF account</a> using an email address or ORCID iD
 
 # Sign in through OSF
 screen.osf.login.message=Sign in with your OSF account to continue

--- a/cas-server-webapp/src/main/webapp/WEB-INF/view/jsp/default/ui/casInstitutionLoginView.jsp
+++ b/cas-server-webapp/src/main/webapp/WEB-INF/view/jsp/default/ui/casInstitutionLoginView.jsp
@@ -60,6 +60,9 @@
                     <form:select class="select" id="institution-form-select" name="select-institution" path="institutions" items="${institutions}" onchange="checkSelect()" autofocus="autofocus" disabled="false"/>
                 </div>
             </section>
+            <spring:eval var="unsupportedInstitutionUrl" expression="@casProperties.getProperty('cas.institution.unsupported.url')"/>
+            <a id="not-your-institution" class='need-help' href="${unsupportedInstitutionUrl}${serviceParam}${institutionIdParam}"><spring:message code="screen.institution.login.select.unsupported"/></a>
+            <br/>
             <c:set var="institutionIdParam" value="&institutionId="/>
         </c:otherwise>
     </c:choose>

--- a/cas-server-webapp/src/main/webapp/WEB-INF/view/jsp/default/ui/casUnsupportedInstitutionLoginView.jsp
+++ b/cas-server-webapp/src/main/webapp/WEB-INF/view/jsp/default/ui/casUnsupportedInstitutionLoginView.jsp
@@ -1,0 +1,63 @@
+<%--
+
+    Copyright (c) 2016. Center for Open Science
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+--%>
+
+<%-- Unsupported Institution information page for OSF --%>
+
+<jsp:directive.include file="includes/top.jsp"/>
+
+<div id="inst-login">
+
+    <script>resizeCasContent();</script>
+
+    <section class="row">
+        <span class="unsupported-inst-body-header"><spring:message code="screen.unsupportedinstitution.login.existing.heading"/></span>
+    </section>
+    <br/>
+    <section class="row">
+        <spring:eval var="osfLoginURL" expression="@casProperties.getProperty('cas.osf.login.url')"/>
+        <c:set var="serviceParam" value="service=${osfLoginContext.isServiceUrl() ? osfLoginContext.getServiceUrl() : ''}"/>
+        <span><spring:message code="screen.unsupportedinstitution.login.existing.osf.message"/></span>
+        <br/>
+        <a id="alt-login-osf" class="btn-alt-login" href="${osfLoginUrl}${serviceParam}">
+            <img class="osf-alt-logo" src="../images/osf-logo.png">
+            <span class="label-login"><spring:message code="screen.unsupportedinstitution.login.existing.osf.button"/></span>
+        </a>
+    </section>
+    <br/>
+    <spring:eval var="osfForgotPasswordInstitutionURL" expression="@casProperties.getProperty('osf.forgotPasswordInstitution.url')"/>
+    <form id="fm1" method="post" action="${osfForgotPasswordInstitutionURL}">
+        <section class="row">
+            <span><spring:message code="screen.unsupportedinstitution.login.existing.institution.message"/></span>
+        </section>
+        <br/>
+        <section id="login" class="row">
+            <input id="username" name="forgot_password-email" class="required" tabindex="1" placeholder="Email" type="email" autofocus="autofocus" accesskey="e" value="" size="25" autocomplete="off">
+        </section>
+        <br/>
+        <section class="row btn-row">
+            <input type="submit" class="btn-submit" name="submit" accesskey="l" tabindex="4" value="Set Password">
+        </section>
+    </form>
+</div>
+
+<c:set var="linkSignIn" value="false"/>
+<c:set var="linkSignOut" value="false"/>
+<c:set var="linkCreateAccount" value="true"/>
+<c:set var="linkBackToOsf" value="true"/>
+
+<jsp:directive.include file="includes/bottom.jsp"/>

--- a/cas-server-webapp/src/main/webapp/WEB-INF/view/jsp/default/ui/includes/top.jsp
+++ b/cas-server-webapp/src/main/webapp/WEB-INF/view/jsp/default/ui/includes/top.jsp
@@ -99,6 +99,10 @@
                             <c:when test="${osfLoginContext.isInstitutionLogin()}">
                                 <spring:message code="screen.institution.login.message" />
                             </c:when>
+                            <c:when test="${osfLoginContext.isUnsupportedInstitutionLogin()}">
+                                <spring:eval var="defaultOsfiURL" expression="@casProperties.getProperty('osf.osfi.url')"/>
+                                <spring:message code="screen.unsupportedinstitution.login.message" arguments="${defaultOsfiURL}" />
+                            </c:when>
                             <c:otherwise>
                                 <spring:message code="screen.osf.login.message" />
                             </c:otherwise>

--- a/cas-server-webapp/src/main/webapp/WEB-INF/webflow/login/login-webflow.xml
+++ b/cas-server-webapp/src/main/webapp/WEB-INF/webflow/login/login-webflow.xml
@@ -106,6 +106,7 @@
         <evaluate expression="loginHandler.beforeLogin(flowRequestContext)" />
         <transition on="osfDefaultLogin" to="viewLoginForm" />
         <transition on="institutionLogin" to="osfInstitutionLogin" />
+        <transition on="unsupportedInstitutionLogin" to="viewUnsupportedInstitutionLoginPage" />
         <transition on="orcidLoginRedirect" to="viewOrcidLoginRedirectPage" />
     </action-state>
 
@@ -115,6 +116,9 @@
     </action-state>
 
     <view-state id="viewInstitutionLoginForm" view="casInstitutionLoginView" model="credential">
+    </view-state>
+
+    <view-state id="viewUnsupportedInstitutionLoginPage" view="casUnsupportedInstitutionLoginView" model="credential">
     </view-state>
 
     <view-state id="viewOrcidLoginRedirectPage" view="casOrcidLoginRedirectView" model="credential">

--- a/cas-server-webapp/src/main/webapp/css/cas.css
+++ b/cas-server-webapp/src/main/webapp/css/cas.css
@@ -498,6 +498,29 @@ footer a:link, footer a:visited {
     color: #BB0000;
 }
 
+#unknown-institution-login, #unknown-institution-login:active {
+    background-image: linear-gradient(to bottom, #2bc1f3 0, #337591 100%);
+    color: white;
+    font-weight: bold;
+}
+
+#unknown-institution-login:hover {
+    cursor: pointer;
+    -webkit-box-shadow: 0px 0px 5px 0px #337591;
+    -moz-box-shadow: 0px 0px 5px 0px #337591;
+    box-shadow: 0px 0px 5px 0px #337591;
+}
+
+#unknown-institution-login .label-login {
+    opacity: 0.9;
+    font-size: 1em;
+}
+
+.unsupported-inst-body-header {
+    font-weight: bold;
+    font-size: 110%;
+}
+
 #service-logo {
     width: 50px;
     text-align: center;

--- a/etc/cas.properties
+++ b/etc/cas.properties
@@ -37,6 +37,7 @@ google.analytics.autoLink=
 cas.osf.login.url=/login?
 cas.logout.url=/logout
 cas.institution.login.url=/login?campaign=institution
+cas.institution.unsupported.url=/login?campaign=unsupportedinstitution
 
 ##
 # Login Rate Limiting
@@ -89,7 +90,9 @@ oauth.orcid.read.timeout=60000
 osf.url=http://localhost:5000/
 osf.resendConfirmation.url=http://localhost:5000/resend/
 osf.forgotPassword.url=http://localhost:5000/forgotpassword/
+osf.forgotPasswordInstitution.url=http://localhost:5000/forgotpassword-institution/
 osf.createAccount.url=http://localhost:5000/register/
+osf.osfi.url=http://localhost:5000/institutions/
 
 ##
 # API URLs


### PR DESCRIPTION
## Ticket

[ENG-2241](https://openscience.atlassian.net/browse/ENG-2241)

## Purpose

**_Replaced by https://github.com/CenterForOpenScience/cas-overlay/pull/195_**

Direct users from institutions that are no longer supported to the necessary pages to login or reclaim their user account.

## Changes

Adds a new page, "I can't find my institution".  This page will direct the user to either login w/ their OSF credentials, create a new account, or migrate an existing account created via institutional SSO.  If they need to migrate, they will be directed to the OSF's "forgot password" page, which will allow them to create an OSF-specific password for the institutional email they use.

## Dev / QA Notes

The main change is a new button on the institutional login page that directs to an informative page.  This page does not add any new functionality itself but provides links to the "login", "create account", and "reclaim institutional account" pages.

This PR links to not-yet-created pages on the OSF.  This can be merged w/o them, but the links will 404 if not already deployed.

## Dev-Ops Notes

Nope.

