### PR TITLE
[No Ticket] Update institutions-auth.xsl with KU Leuven

### DIFF
--- a/etc/institutions-auth.xsl
+++ b/etc/institutions-auth.xsl
@@ -84,6 +84,18 @@
                             <suffix/>
                         </user>
                     </xsl:when>
+                    <!-- KU Leuven Libraries (KULEUVEN)-->
+                    <xsl:when test="$idp='urn:mace:kuleuven.be:kulassoc:kuleuven.be'">
+                        <id>kuleuven</id>
+                        <user>
+                            <username><xsl:value-of select="//attribute[@name='mail']/@value"/></username>
+                            <fullname><xsl:value-of select="//attribute[@name='displayName']/@value"/></fullname>
+                            <familyName><xsl:value-of select="//attribute[@name='sn']/@value"/></familyName>
+                            <givenName><xsl:value-of select="//attribute[@name='givenName']/@value"/></givenName>
+                            <middleNames/>
+                            <suffix/>
+                        </user>
+                    </xsl:when>
                     <!-- Princeton University (PU) -->
                     <!--
                         The departmentRaw and eduPerson attributes are for local testing purpose only.


### PR DESCRIPTION
### DevOps Notes

* This PR is for local development and reference only. No need to merge into the `develop` or `master` for now.
* Supports OSF ticket [ENG-2494](https://openscience.atlassian.net/browse/ENG-2494) PR [osf.io/pull/9586](https://github.com/CenterForOpenScience/osf.io/pull/9586).
* Please update private `jetty` settings by adding the following to the file `institutions-auth.xsl` under the SAML protocol section.

```xml
<!-- KU Leuven Libraries (KULEUVEN)-->
<xsl:when test="$idp='urn:mace:kuleuven.be:kulassoc:kuleuven.be'">
    <id>kuleuven</id>
    <user>
        <username><xsl:value-of select="//attribute[@name='mail']/@value"/></username>
        <fullname><xsl:value-of select="//attribute[@name='displayName']/@value"/></fullname>
        <familyName><xsl:value-of select="//attribute[@name='sn']/@value"/></familyName>
        <givenName><xsl:value-of select="//attribute[@name='givenName']/@value"/></givenName>
        <middleNames/>
        <suffix/>
    </user>
</xsl:when>
```