### PR TITLE
[ENG-2722]Update VCU (local) with the department attribute

### DIFF
--- a/etc/institutions-auth.xsl
+++ b/etc/institutions-auth.xsl
@@ -167,6 +167,20 @@
                             <suffix/>
                         </user>
                     </xsl:when>
+                    <!-- Virginia Commonwealth University (VCU) -->
+                    <xsl:when test="$idp='https://shibboleth.vcu.edu/idp/shibboleth'">
+                        <id>vcu</id>
+                        <user>
+                            <username><xsl:value-of select="//attribute[@name='mail']/@value"/></username>
+                            <departmentRaw><xsl:value-of select="//attribute[@name='department']/@value"/></departmentRaw>
+                            <eduPerson>false</eduPerson>
+                            <fullname><xsl:value-of select="//attribute[@name='displayName']/@value"/></fullname>
+                            <familyName/>
+                            <givenName/>
+                            <middleNames/>
+                            <suffix/>
+                        </user>
+                    </xsl:when>
                     <!--  Unknown Identity Provider  -->
                     <xsl:otherwise>
                         <xsl:message terminate="yes">Error: Unknown Identity Provider '<xsl:value-of select="$idp"/>'</xsl:message>


### PR DESCRIPTION
## Ticket

https://openscience.atlassian.net/browse/ENG-2722

## Purpose

Update VCU settings to allow the department attribute.

## Changes

Changes here are local dev only but serves as a guide to private server settings.

## Dev / QA Notes

N / A

## Dev-Ops Notes

### Apache / Shibboleth (Prod)

Add this to `attribute-map.xml`, preferably under settings for University of Arizona (UA)

```xml
<!-- Virginia Commonwealth University (VCU) -->
<!-- The attribute that VCU released has a friendly name "vcuEduPersonDepartment", which OSF Shibboleth doesn't use. -->
<Attribute name="urn:oid:1.3.6.1.4.1.10384.0.0.3.1" id="department"/>
```

### Jetty / CAS (Prod)

Add the following to VCU attributes in `institutions-auth.xsl`

```xml
<departmentRaw><xsl:value-of select="//attribute[@name='department']/@value"/></departmentRaw>
<eduPerson>false</eduPerson>
```

